### PR TITLE
node: guardian watcher leak fixes (EVM + Sui) and leak-detection harness

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/wormhole-foundation/wormhole/sdk v0.0.0-20220926172624-4b38dc650bb0
 	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
+	gopkg.in/yaml.v3 v3.0.1
 	nhooyr.io/websocket v1.8.7
 )
 
@@ -303,7 +304,7 @@ require (
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/regen-network/cosmos-proto v0.3.1 // indirect
-	github.com/rjeczalik/notify v0.9.1 // indirect
+	github.com/rjeczalik/notify v0.9.3 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.27.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
@@ -371,7 +372,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
 

--- a/node/go.mod
+++ b/node/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/gagliardetto/solana-go v1.8.4
 	github.com/gorilla/mux v1.8.0
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.2
@@ -65,6 +65,7 @@ require (
 	github.com/prometheus/common v0.60.0
 	github.com/wormhole-foundation/wormchain v0.0.0-00010101000000-000000000000
 	github.com/wormhole-foundation/wormhole/sdk v0.0.0-20220926172624-4b38dc650bb0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
 	nhooyr.io/websocket v1.8.7
 )
@@ -352,7 +353,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/fx v1.23.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect

--- a/node/go.sum
+++ b/node/go.sum
@@ -2705,8 +2705,9 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/remyoudompheng/go-dbus v0.0.0-20121104212943-b7232d34b1d5/go.mod h1:+u151txRmLpwxBmpYn9z3d1sdJdjRPQpsXuYeY9jNls=
 github.com/remyoudompheng/go-liblzma v0.0.0-20190506200333-81bf2d431b96/go.mod h1:90HvCY7+oHHUKkbeMCiHt1WuFR2/hPJ9QrljDG+v6ls=
 github.com/remyoudompheng/go-misc v0.0.0-20190427085024-2d6ac652a50e/go.mod h1:80FQABjoFzZ2M5uEa6FUaJYEmqU2UOKojlFVak1UAwI=
-github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
+github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=
+github.com/rjeczalik/notify v0.9.3/go.mod h1:gF3zSOrafR9DQEWSE8TjfI9NkooDxbyT4UgRGKZA0lc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -3594,6 +3595,7 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181029174526-d69651ed3497/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/node/hack/leakharness/cmd/leakharness/main.go
+++ b/node/hack/leakharness/cmd/leakharness/main.go
@@ -1,0 +1,107 @@
+// Command leakharness drives a guardian leak-detection scenario and
+// writes a JSON summary plus a sample time series to disk.
+//
+// Usage:
+//
+//	leakharness run <scenario.yaml> [--out runs/<ts>/]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/harness"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: leakharness run <scenario.yaml> [--out <dir>]")
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "run":
+		exitCode := runCmd(os.Args[2:])
+		os.Exit(exitCode)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", os.Args[1])
+		os.Exit(2)
+	}
+}
+
+func runCmd(args []string) int {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	out := fs.String("out", "", "output directory (default: runs/<scenario>-<ts>/)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: leakharness run [--out <dir>] <scenario.yaml>")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() < 1 {
+		fs.Usage()
+		return 2
+	}
+	scenarioPath := fs.Arg(0)
+
+	scenario, err := harness.LoadScenario(scenarioPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load scenario:", err)
+		return 1
+	}
+
+	outDir := *out
+	if outDir == "" {
+		ts := time.Now().UTC().Format("20060102T150405Z")
+		outDir = filepath.Join("runs", fmt.Sprintf("%s-%s", scenario.Name, ts))
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "mkdir:", err)
+		return 1
+	}
+
+	h, err := harness.New(scenario)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "new harness:", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), scenario.Duration+2*time.Minute)
+	defer cancel()
+
+	fmt.Printf("running scenario %q for %s, sample interval %s, OOM cap %d MiB\n",
+		scenario.Name, scenario.Duration, scenario.SampleInterval, scenario.OOMCapBytes>>20)
+
+	summary, err := h.Run(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "run:", err)
+		return 1
+	}
+
+	summaryPath := filepath.Join(outDir, "summary.json")
+	if err := harness.WriteSummary(summaryPath, summary); err != nil {
+		fmt.Fprintln(os.Stderr, "write summary:", err)
+		return 1
+	}
+
+	fmt.Printf("\nverdict: %s\n", summary.Verdict)
+	fmt.Printf("samples: %d\n", summary.SampleCount)
+	fmt.Printf("peak RSS: %d MiB\n", summary.PeakRSSBytes>>20)
+	fmt.Printf("peak goroutines: %d\n", summary.PeakGoroutines)
+	fmt.Printf("slopes:\n")
+	fmt.Printf("  rss_mb_per_hour:        %.2f\n", summary.Slopes.RSSMBPerHour)
+	fmt.Printf("  heap_inuse_mb_per_hour: %.2f\n", summary.Slopes.HeapInuseMBPerHour)
+	fmt.Printf("  goroutines_per_hour:    %.2f\n", summary.Slopes.GoroutinesPerHour)
+	fmt.Printf("  fds_per_hour:           %.2f\n", summary.Slopes.FDsPerHour)
+	fmt.Printf("\nsummary written to %s\n", summaryPath)
+
+	if summary.Verdict == harness.VerdictKilledOOM {
+		return 1
+	}
+	return 0
+}
+

--- a/node/hack/leakharness/cmd/leakharness/main.go
+++ b/node/hack/leakharness/cmd/leakharness/main.go
@@ -35,8 +35,10 @@ func main() {
 func runCmd(args []string) int {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	out := fs.String("out", "", "output directory (default: runs/<scenario>-<ts>/)")
+	pprofAddr := fs.String("pprof-addr", "127.0.0.1:6061",
+		"address for live net/http/pprof server (set to empty string to disable; bind only to loopback because heap dumps may contain sensitive state)")
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: leakharness run [--out <dir>] <scenario.yaml>")
+		fmt.Fprintln(os.Stderr, "usage: leakharness run [--out <dir>] [--pprof-addr <host:port>] <scenario.yaml>")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -69,12 +71,23 @@ func runCmd(args []string) int {
 		fmt.Fprintln(os.Stderr, "new harness:", err)
 		return 1
 	}
+	h.ProfileDir = outDir
+
+	stopPprof, pprofAddrActual, err := harness.StartPprofServer(*pprofAddr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "pprof server:", err)
+		return 1
+	}
+	defer func() { _ = stopPprof() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), scenario.Duration+2*time.Minute)
 	defer cancel()
 
 	fmt.Printf("running scenario %q for %s, sample interval %s, OOM cap %d MiB\n",
 		scenario.Name, scenario.Duration, scenario.SampleInterval, scenario.OOMCapBytes>>20)
+	if pprofAddrActual != "" {
+		fmt.Printf("live pprof: http://%s/debug/pprof/ (heap, goroutine, profile, allocs)\n", pprofAddrActual)
+	}
 
 	summary, err := h.Run(ctx)
 	if err != nil {
@@ -98,6 +111,15 @@ func runCmd(args []string) int {
 	fmt.Printf("  goroutines_per_hour:    %.2f\n", summary.Slopes.GoroutinesPerHour)
 	fmt.Printf("  fds_per_hour:           %.2f\n", summary.Slopes.FDsPerHour)
 	fmt.Printf("\nsummary written to %s\n", summaryPath)
+	if summary.Profiles.HeapStart != "" && summary.Profiles.HeapEnd != "" {
+		fmt.Printf("heap diff:    go tool pprof -base %s %s\n",
+			filepath.Join(outDir, summary.Profiles.HeapStart),
+			filepath.Join(outDir, summary.Profiles.HeapEnd))
+	}
+	if summary.Profiles.GoroutineEnd != "" {
+		fmt.Printf("goroutines:   go tool pprof %s\n",
+			filepath.Join(outDir, summary.Profiles.GoroutineEnd))
+	}
 
 	if summary.Verdict == harness.VerdictKilledOOM {
 		return 1

--- a/node/hack/leakharness/fakerpc/common/family.go
+++ b/node/hack/leakharness/fakerpc/common/family.go
@@ -1,0 +1,52 @@
+// Package common defines the chain-family abstraction the leak
+// harness uses to plug in fake-RPC implementations per chain.
+//
+// Each chain family (EVM, Sui, Cosmwasm, XRPL, …) provides:
+//
+//   1. A FaultableServer — an httptest-style fake whose behaviour can
+//      be flipped at runtime;
+//   2. A Worker — a loop that dials the fake, performs whatever
+//      chain-family-specific lifecycle exercises the relevant leak
+//      class, and closes cleanly. The loop must respect ctx.Done.
+//
+// The harness instantiates one (server, worker) pair per configured
+// chain and runs them concurrently.
+package common
+
+import "context"
+
+// Fault enumerates the failure modes a FaultableServer can be driven
+// into. Not every family supports every fault; unsupported faults are
+// no-ops by convention.
+type Fault int
+
+const (
+	FaultNone Fault = iota
+	FaultCloseAllConnections
+	FaultMalformed
+	FaultSlow
+	FaultStuck
+)
+
+// FaultableServer is the runtime contract for a fake RPC.
+type FaultableServer interface {
+	URL() string
+	Set(f Fault)
+	Stop()
+}
+
+// Worker is the contract for a chain-family-specific lifecycle loop.
+type Worker interface {
+	// Run loops dial-use-close against `serverURL` until ctx is
+	// cancelled. Errors are swallowed by design: the harness measures
+	// leakage, not correctness of individual calls.
+	Run(ctx context.Context, serverURL string)
+}
+
+// Family bundles the constructor for a fake server and a worker.
+// `Name` is the FakeKind identifier used by scenarios.
+type Family struct {
+	Name      string
+	NewServer func(id uint64) FaultableServer
+	NewWorker func() Worker
+}

--- a/node/hack/leakharness/fakerpc/cosmwasm/cosmwasm.go
+++ b/node/hack/leakharness/fakerpc/cosmwasm/cosmwasm.go
@@ -1,0 +1,134 @@
+// Package cosmwasm is a minimal fake Tendermint RPC server and a
+// polling worker for the leak harness. The cosmwasm watcher polls
+// `/abci_info` and `/block_results` over HTTP; this fake answers both
+// with a tiny canned payload.
+package cosmwasm
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+)
+
+type Server struct {
+	mu            sync.Mutex
+	fault         common.Fault
+	srv           *httptest.Server
+	requestCount  int64
+	hijackedConns []net.Conn
+}
+
+var Family = common.Family{
+	Name: "cosmwasm",
+	NewServer: func(_ uint64) common.FaultableServer {
+		return New()
+	},
+	NewWorker: func() common.Worker {
+		return &Worker{}
+	},
+}
+
+func New() *Server {
+	s := &Server{}
+	s.srv = httptest.NewServer(http.HandlerFunc(s.handle))
+	return s
+}
+
+func (s *Server) URL() string { return s.srv.URL }
+
+func (s *Server) Set(f common.Fault) {
+	s.mu.Lock()
+	s.fault = f
+	s.mu.Unlock()
+}
+
+func (s *Server) Stop() {
+	s.mu.Lock()
+	for _, c := range s.hijackedConns {
+		_ = c.Close()
+	}
+	s.hijackedConns = nil
+	s.mu.Unlock()
+	s.srv.Close()
+}
+
+func (s *Server) RequestCount() int64 { return atomic.LoadInt64(&s.requestCount) }
+
+const abciInfoResponse = `{"jsonrpc":"2.0","id":1,"result":{"response":{"last_block_height":"42","last_block_app_hash":""}}}`
+const blockResultsResponse = `{"jsonrpc":"2.0","id":1,"result":{"height":"42","txs_results":[],"end_block_events":[]}}`
+
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	atomic.AddInt64(&s.requestCount, 1)
+	_, _ = io.Copy(io.Discard, r.Body)
+
+	s.mu.Lock()
+	fault := s.fault
+	s.mu.Unlock()
+
+	switch fault {
+	case common.FaultCloseAllConnections:
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			c, _, err := hj.Hijack()
+			if err == nil {
+				s.mu.Lock()
+				s.hijackedConns = append(s.hijackedConns, c)
+				s.mu.Unlock()
+				_ = c.Close()
+				return
+			}
+		}
+		http.Error(w, "disconnected", http.StatusBadGateway)
+	case common.FaultMalformed:
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	case common.FaultSlow:
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
+		fallthrough
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "block_results"):
+			_, _ = w.Write([]byte(blockResultsResponse))
+		default:
+			_, _ = w.Write([]byte(abciInfoResponse))
+		}
+	}
+}
+
+type Worker struct{}
+
+func (w *Worker) Run(ctx context.Context, url string) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	body := []byte(`{}`)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		req, _ := http.NewRequestWithContext(ctx, "POST", url+"/abci_info", bytes.NewReader(body))
+		resp, err := client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/node/hack/leakharness/fakerpc/cosmwasm/cosmwasm_test.go
+++ b/node/hack/leakharness/fakerpc/cosmwasm/cosmwasm_test.go
@@ -1,0 +1,67 @@
+package cosmwasm_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/cosmwasm"
+)
+
+func TestCosmwasmFamily_HealthyRoundtrips(t *testing.T) {
+	srv := cosmwasm.New()
+	defer srv.Stop()
+
+	worker := &cosmwasm.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	worker.Run(ctx, srv.URL())
+
+	require.Greater(t, srv.RequestCount(), int64(2),
+		"healthy worker should issue multiple POSTs in 500ms; got %d", srv.RequestCount())
+}
+
+func TestCosmwasmFamily_StopAfterFault(t *testing.T) {
+	srv := cosmwasm.New()
+	srv.Set(common.FaultCloseAllConnections)
+
+	worker := &cosmwasm.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	worker.Run(ctx, srv.URL())
+
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2s")
+	}
+}
+
+func TestCosmwasmFamily_WorkerReconnectsAfterFault(t *testing.T) {
+	srv := cosmwasm.New()
+	defer srv.Stop()
+
+	worker := &cosmwasm.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		srv.Set(common.FaultCloseAllConnections)
+		time.Sleep(100 * time.Millisecond)
+		srv.Set(common.FaultNone)
+	}()
+
+	worker.Run(ctx, srv.URL())
+
+	require.Greater(t, srv.RequestCount(), int64(2),
+		"worker must continue polling through the fault flap; got %d", srv.RequestCount())
+}

--- a/node/hack/leakharness/fakerpc/evm/family.go
+++ b/node/hack/leakharness/fakerpc/evm/family.go
@@ -1,0 +1,59 @@
+package evm
+
+import (
+	"context"
+	"time"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"go.uber.org/zap"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors"
+)
+
+// Family exposes the EVM fake to the harness orchestrator.
+var Family = common.Family{
+	Name: "evm",
+	NewServer: func(id uint64) common.FaultableServer {
+		return New(id)
+	},
+	NewWorker: func() common.Worker {
+		logger := zap.NewNop()
+		return &Worker{logger: logger}
+	},
+}
+
+// Worker exercises the EthereumBaseConnector lifecycle: dial against
+// the fake, hold the connection briefly, Close. This is the cycle that
+// production supervisor restarts trace through; the leak this whole
+// harness exists to detect lives here.
+type Worker struct {
+	logger *zap.Logger
+}
+
+func (w *Worker) Run(ctx context.Context, serverURL string) {
+	addr := ethCommon.HexToAddress("0x0000000000000000000000000000000000000000")
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		dialCtx, dialCancel := context.WithTimeout(ctx, 5*time.Second)
+		conn, err := connectors.NewEthereumBaseConnector(dialCtx, "evm", serverURL, addr, nil, w.logger)
+		dialCancel()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+		_ = conn.Close()
+	}
+}

--- a/node/hack/leakharness/fakerpc/evm/server.go
+++ b/node/hack/leakharness/fakerpc/evm/server.go
@@ -1,0 +1,276 @@
+// Package evm provides a minimal in-process Ethereum-compatible
+// JSON-RPC server for the leak harness. It speaks just enough of the
+// Ethereum JSON-RPC protocol to let a guardian EVM watcher complete
+// `verifyEvmChainID` and stay sufficiently happy across a few seconds
+// of activity.
+//
+// The server is *not* a faithful emulator: it does not produce realistic
+// chain state, gossip blocks, or honour finality semantics. Its purpose
+// is purely to exercise the connector lifecycle — dial, request, error,
+// close — which is where the leak class we are guarding against lives.
+//
+// Fault injection is exposed via `Set(fault FaultMode)`; Phase 2 wires
+// those to behaviour changes (close all websockets, freeze the height,
+// return malformed JSON, etc.).
+package evm
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+)
+
+// FaultMode controls how the server responds to requests.
+type FaultMode int
+
+const (
+	ModeHealthy FaultMode = iota
+	// ModeCloseAllWS instructs newly accepted WebSocket connections to
+	// be closed immediately after the handshake, and currently-active
+	// connections to be dropped on the next request. Use this to simulate
+	// the mezo testnet flap.
+	ModeCloseAllWS
+	// ModeMalformed returns valid HTTP 200 but garbage JSON-RPC bodies.
+	ModeMalformed
+	// ModeSlow holds responses for `slowDelay` before answering. Set
+	// `SetSlowDelay` for the actual duration.
+	ModeSlow
+	// ModeStuck answers `eth_blockNumber` with the same value forever.
+	ModeStuck
+)
+
+// Server is a controllable JSON-RPC endpoint. The zero value is unusable;
+// construct with New.
+type Server struct {
+	chainID uint64
+
+	mu        sync.Mutex
+	mode      FaultMode
+	slowDelay int64 // ns, atomic
+	stuckHt   uint64
+
+	upgrader websocket.Upgrader
+
+	openWS sync.Map // *websocket.Conn -> struct{}
+
+	srv *httptest.Server
+
+	requestCount int64
+}
+
+// New constructs an EVM fake RPC for the given chain ID and starts
+// listening. Closure (via Stop or t.Cleanup) is the caller's job.
+func New(chainID uint64) *Server {
+	s := &Server{
+		chainID: chainID,
+		mode:    ModeHealthy,
+		stuckHt: 0x1000,
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+	}
+	s.srv = httptest.NewServer(http.HandlerFunc(s.handle))
+	return s
+}
+
+// NewT is the testing.T-aware constructor that registers t.Cleanup.
+func NewT(t *testing.T, chainID uint64) *Server {
+	t.Helper()
+	s := New(chainID)
+	t.Cleanup(s.Stop)
+	return s
+}
+
+// Stop tears the server down and closes any active WebSocket
+// connections.
+func (s *Server) Stop() {
+	s.closeAllWS()
+	s.srv.Close()
+}
+
+// URL returns the ws:// URL of the fake. Suitable for passing to
+// `rpc.DialContext`.
+func (s *Server) URL() string {
+	return "ws" + strings.TrimPrefix(s.srv.URL, "http")
+}
+
+// Set switches the server into a new fault mode. Subsequent requests
+// honour the new mode. This is the FaultableServer interface
+// implementation used by the harness.
+func (s *Server) Set(f common.Fault) {
+	s.setMode(translateFault(f))
+}
+
+// SetMode is the EVM-native equivalent of Set, taking an internal
+// FaultMode directly. Useful for fine-grained EVM-only tests.
+func (s *Server) SetMode(m FaultMode) {
+	s.setMode(m)
+}
+
+func (s *Server) setMode(m FaultMode) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mode = m
+	if m == ModeCloseAllWS {
+		s.closeAllWSLocked()
+	}
+}
+
+func translateFault(f common.Fault) FaultMode {
+	switch f {
+	case common.FaultNone:
+		return ModeHealthy
+	case common.FaultCloseAllConnections:
+		return ModeCloseAllWS
+	case common.FaultMalformed:
+		return ModeMalformed
+	case common.FaultSlow:
+		return ModeSlow
+	case common.FaultStuck:
+		return ModeStuck
+	default:
+		return ModeHealthy
+	}
+}
+
+// SetSlowDelay configures the artificial delay applied in ModeSlow.
+func (s *Server) SetSlowDelay(ns int64) {
+	atomic.StoreInt64(&s.slowDelay, ns)
+}
+
+// RequestCount returns the number of JSON-RPC requests served since
+// startup.
+func (s *Server) RequestCount() int64 {
+	return atomic.LoadInt64(&s.requestCount)
+}
+
+func (s *Server) mode_() FaultMode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mode
+}
+
+func (s *Server) closeAllWS() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeAllWSLocked()
+}
+
+func (s *Server) closeAllWSLocked() {
+	s.openWS.Range(func(k, _ interface{}) bool {
+		if c, ok := k.(*websocket.Conn); ok {
+			_ = c.Close()
+		}
+		s.openWS.Delete(k)
+		return true
+	})
+}
+
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		s.serveWS(w, r)
+		return
+	}
+	s.serveHTTP(w, r)
+}
+
+func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	var req jsonRPCReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	atomic.AddInt64(&s.requestCount, 1)
+	resp := s.dispatch(req)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) serveWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	if s.mode_() == ModeCloseAllWS {
+		_ = conn.Close()
+		return
+	}
+	s.openWS.Store(conn, struct{}{})
+	defer func() {
+		s.openWS.Delete(conn)
+		_ = conn.Close()
+	}()
+
+	for {
+		var req jsonRPCReq
+		if err := conn.ReadJSON(&req); err != nil {
+			return
+		}
+		atomic.AddInt64(&s.requestCount, 1)
+		// Snapshot the fault mode once per iteration so a mid-handler
+		// flip cannot wedge the response state machine.
+		mode := s.mode_()
+		if mode == ModeCloseAllWS {
+			return
+		}
+		if mode == ModeSlow {
+			delay := time.Duration(atomic.LoadInt64(&s.slowDelay))
+			if delay > 0 {
+				time.Sleep(delay)
+			}
+		}
+		resp := s.dispatch(req)
+		if mode == ModeMalformed {
+			_ = conn.WriteMessage(websocket.TextMessage, []byte("not json"))
+			continue
+		}
+		if err := conn.WriteJSON(resp); err != nil {
+			return
+		}
+	}
+}
+
+type jsonRPCReq struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+	ID      json.RawMessage `json:"id"`
+}
+
+type jsonRPCResp struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcErr         `json:"error,omitempty"`
+}
+
+type rpcErr struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (s *Server) dispatch(req jsonRPCReq) jsonRPCResp {
+	resp := jsonRPCResp{JSONRPC: "2.0", ID: req.ID}
+	switch req.Method {
+	case "eth_chainId":
+		resp.Result = fmt.Sprintf("0x%x", s.chainID)
+	case "net_version":
+		resp.Result = fmt.Sprintf("%d", s.chainID)
+	case "eth_blockNumber":
+		resp.Result = fmt.Sprintf("0x%x", s.stuckHt)
+	default:
+		resp.Error = &rpcErr{Code: -32601, Message: "method not found: " + req.Method}
+	}
+	return resp
+}

--- a/node/hack/leakharness/fakerpc/sui/sui.go
+++ b/node/hack/leakharness/fakerpc/sui/sui.go
@@ -1,0 +1,157 @@
+// Package sui implements a fake Sui JSON-RPC server and a worker that
+// exercises the HTTP-poll lifecycle used by the Sui watcher.
+//
+// Unlike the EVM family, which imports node/pkg/watchers/evm/connectors
+// directly and so detects regressions in real watcher code, this Sui
+// worker is a *generic* HTTP poll loop. It exercises Go's net/http
+// transport lifecycle (which is also a leak surface) but it does NOT
+// import or exercise node/pkg/watchers/sui itself.
+//
+// Known gap: a re-introduction of the historical hot-retry bug
+// (commit 11f66039) in the real sui watcher would NOT be caught here.
+// Promoting this worker to drive `(*sui.Watcher).Run` against the
+// fake is a deliberate follow-up — it requires either pulling the
+// watcher's wiring inside-out (chain config, msg channel, observation
+// channel, signer, …) or building a thin shim. Tracked as a future
+// improvement on the harness backlog.
+package sui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+)
+
+type Server struct {
+	mu               sync.Mutex
+	fault            common.Fault
+	srv              *httptest.Server
+	requestCount     int64
+	hijackedConns    []net.Conn
+}
+
+var Family = common.Family{
+	Name: "sui",
+	NewServer: func(_ uint64) common.FaultableServer {
+		return New()
+	},
+	NewWorker: func() common.Worker {
+		return &Worker{}
+	},
+}
+
+func New() *Server {
+	s := &Server{}
+	s.srv = httptest.NewServer(http.HandlerFunc(s.handle))
+	return s
+}
+
+func (s *Server) URL() string { return s.srv.URL }
+
+func (s *Server) Set(f common.Fault) {
+	s.mu.Lock()
+	s.fault = f
+	s.mu.Unlock()
+}
+
+func (s *Server) Stop() {
+	s.mu.Lock()
+	for _, c := range s.hijackedConns {
+		_ = c.Close()
+	}
+	s.hijackedConns = nil
+	s.mu.Unlock()
+	s.srv.Close()
+}
+
+func (s *Server) RequestCount() int64 { return atomic.LoadInt64(&s.requestCount) }
+
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	atomic.AddInt64(&s.requestCount, 1)
+	_, _ = io.Copy(io.Discard, r.Body)
+
+	s.mu.Lock()
+	fault := s.fault
+	s.mu.Unlock()
+
+	switch fault {
+	case common.FaultCloseAllConnections:
+		// Hijack the connection to close it without sending a response.
+		// Track the hijacked conn so Stop() can guarantee closure even
+		// if the client never noticed the half-close.
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			c, _, err := hj.Hijack()
+			if err == nil {
+				s.mu.Lock()
+				s.hijackedConns = append(s.hijackedConns, c)
+				s.mu.Unlock()
+				_ = c.Close()
+				return
+			}
+		}
+		http.Error(w, "disconnected", http.StatusBadGateway)
+	case common.FaultMalformed:
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	case common.FaultSlow:
+		// Interruptible delay so an in-flight slow request does not
+		// pin the server goroutine past r.Context().Done.
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
+		fallthrough
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		// Minimal "result": empty events payload, matching what Sui
+		// returns when no events match the filter.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result": map[string]any{
+				"data":      []any{},
+				"hasNextPage": false,
+			},
+		})
+	}
+}
+
+// Worker polls the fake at 50 ms intervals and ignores all
+// responses. The tight loop is intentional: it is the shape that
+// previously leaked.
+type Worker struct{}
+
+func (w *Worker) Run(ctx context.Context, url string) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"suix_queryEvents","params":[]}`)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		req, _ := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+

--- a/node/hack/leakharness/fakerpc/sui/sui_test.go
+++ b/node/hack/leakharness/fakerpc/sui/sui_test.go
@@ -1,0 +1,72 @@
+package sui_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/sui"
+)
+
+func TestSuiFamily_HealthyRoundtrips(t *testing.T) {
+	srv := sui.New()
+	defer srv.Stop()
+
+	worker := &sui.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	worker.Run(ctx, srv.URL())
+
+	require.Greater(t, srv.RequestCount(), int64(3),
+		"healthy worker should issue many requests in 500ms; got %d", srv.RequestCount())
+}
+
+func TestSuiFamily_WorkerReconnectsAfterFault(t *testing.T) {
+	srv := sui.New()
+	defer srv.Stop()
+
+	worker := &sui.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	// Flip the fault on after the worker has had a chance to run a few
+	// healthy iterations, then heal, and verify the request count
+	// continues to climb past the fault.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		srv.Set(common.FaultCloseAllConnections)
+		time.Sleep(100 * time.Millisecond)
+		srv.Set(common.FaultNone)
+	}()
+
+	worker.Run(ctx, srv.URL())
+
+	require.Greater(t, srv.RequestCount(), int64(3),
+		"worker must keep reconnecting through fault flap; got %d requests", srv.RequestCount())
+}
+
+func TestSuiFamily_StopClosesHijackedConns(t *testing.T) {
+	srv := sui.New()
+
+	srv.Set(common.FaultCloseAllConnections)
+	worker := &sui.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	worker.Run(ctx, srv.URL())
+
+	// Stop must not block or panic even with hijacked connections
+	// queued up. Verified by simply returning within the test deadline.
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2s")
+	}
+}

--- a/node/hack/leakharness/fakerpc/xrpl/xrpl.go
+++ b/node/hack/leakharness/fakerpc/xrpl/xrpl.go
@@ -1,0 +1,135 @@
+// Package xrpl is a minimal fake XRPL WebSocket server and a worker
+// that exercises the WS subscribe/read loop. XRPL leaks would surface
+// here similarly to EVM (orphaned WS dispatchers across reconnect
+// storms).
+package xrpl
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+)
+
+type Server struct {
+	mu           sync.Mutex
+	fault        common.Fault
+	upgrader     websocket.Upgrader
+	srv          *httptest.Server
+	openWS       sync.Map
+	requestCount int64
+}
+
+var Family = common.Family{
+	Name: "xrpl",
+	NewServer: func(_ uint64) common.FaultableServer {
+		return New()
+	},
+	NewWorker: func() common.Worker {
+		return &Worker{}
+	},
+}
+
+func New() *Server {
+	s := &Server{
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+	}
+	s.srv = httptest.NewServer(http.HandlerFunc(s.handle))
+	return s
+}
+
+func (s *Server) URL() string { return "ws" + strings.TrimPrefix(s.srv.URL, "http") }
+
+func (s *Server) Set(f common.Fault) {
+	s.mu.Lock()
+	s.fault = f
+	s.mu.Unlock()
+	if f == common.FaultCloseAllConnections {
+		s.closeAllWS()
+	}
+}
+
+func (s *Server) Stop() {
+	s.closeAllWS()
+	s.srv.Close()
+}
+
+func (s *Server) RequestCount() int64 { return atomic.LoadInt64(&s.requestCount) }
+
+func (s *Server) closeAllWS() {
+	s.openWS.Range(func(k, _ any) bool {
+		if c, ok := k.(*websocket.Conn); ok {
+			_ = c.Close()
+		}
+		s.openWS.Delete(k)
+		return true
+	})
+}
+
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	s.openWS.Store(conn, struct{}{})
+	defer func() {
+		s.openWS.Delete(conn)
+		_ = conn.Close()
+	}()
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		atomic.AddInt64(&s.requestCount, 1)
+
+		s.mu.Lock()
+		fault := s.fault
+		s.mu.Unlock()
+		if fault == common.FaultCloseAllConnections {
+			return
+		}
+		_ = msg // ignore content; the worker just needs roundtrip semantics
+		// Minimal response indicating subscription accepted.
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response","status":"success","result":{}}`))
+	}
+}
+
+type Worker struct{}
+
+func (w *Worker) Run(ctx context.Context, url string) {
+	dialer := websocket.DefaultDialer
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		conn, _, err := dialer.DialContext(ctx, url, nil)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+		// Send a subscribe ping, read response, then close — exercises the
+		// dial/write/read/close cycle that XRPL watchers run.
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"command":"subscribe","streams":["transactions"]}`))
+		_, _, _ = conn.ReadMessage()
+		_ = conn.Close()
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/node/hack/leakharness/fakerpc/xrpl/xrpl_test.go
+++ b/node/hack/leakharness/fakerpc/xrpl/xrpl_test.go
@@ -1,0 +1,47 @@
+package xrpl_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/xrpl"
+)
+
+func TestXRPLFamily_HealthyRoundtrips(t *testing.T) {
+	srv := xrpl.New()
+	defer srv.Stop()
+
+	worker := &xrpl.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	worker.Run(ctx, srv.URL())
+
+	require.Greater(t, srv.RequestCount(), int64(2),
+		"healthy worker should complete multiple WS roundtrips in 500ms; got %d", srv.RequestCount())
+}
+
+func TestXRPLFamily_FaultCloseDropsConnections(t *testing.T) {
+	srv := xrpl.New()
+	defer srv.Stop()
+
+	worker := &xrpl.Worker{}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// Toggle the fault mid-run so the worker is forced to redial.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		srv.Set(common.FaultCloseAllConnections)
+		time.Sleep(100 * time.Millisecond)
+		srv.Set(common.FaultNone)
+	}()
+
+	worker.Run(ctx, srv.URL())
+
+	require.Greater(t, srv.RequestCount(), int64(1),
+		"worker must reconnect after WS close; got %d", srv.RequestCount())
+}

--- a/node/hack/leakharness/harness/harness.go
+++ b/node/hack/leakharness/harness/harness.go
@@ -1,0 +1,295 @@
+// Package harness orchestrates leak-detection scenarios against the
+// guardian watcher code in-process. See `.claude/tasks/guardian-leak-harness.md`
+// for the design.
+//
+// The harness exercises the lifecycle that production leaks live in:
+//
+//   dial connector -> use connector -> close connector -> repeat
+//
+// faulted by an injectable fake-RPC. It does NOT spawn guardiand as a
+// subprocess; that fidelity is deferred to a Phase 5 follow-up. The
+// in-process approach catches the connector-restart leak class
+// (sui hot-loop, evm restart) that motivated this harness, without the
+// 40-flag guardiand startup overhead.
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/cosmwasm"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/evm"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/sui"
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/xrpl"
+)
+
+// familyRegistry maps a FakeKind to the chain-family hooks the harness
+// needs. New chain families register themselves here.
+var familyRegistry = map[FakeKind]common.Family{
+	FakeEVM:      evm.Family,
+	FakeSui:      sui.Family,
+	FakeCosmwasm: cosmwasm.Family,
+	FakeXRPL:     xrpl.Family,
+}
+
+// Verdict labels the outcome of a harness run.
+type Verdict string
+
+const (
+	VerdictOK         Verdict = "ok"
+	VerdictKilledOOM  Verdict = "killed_oom"
+	VerdictAborted    Verdict = "aborted"
+)
+
+// Summary is the JSON-serialisable record of a single scenario run.
+type Summary struct {
+	Scenario       string    `json:"scenario"`
+	Description    string    `json:"description"`
+	StartedAt      time.Time `json:"started_at"`
+	CompletedAt    time.Time `json:"completed_at"`
+	SampleCount    int       `json:"sample_count"`
+	Verdict        Verdict   `json:"verdict"`
+	OOMCapBytes    uint64    `json:"oom_cap_bytes"`
+	PeakRSSBytes   uint64    `json:"peak_rss_bytes"`
+	PeakGoroutines int       `json:"peak_goroutines"`
+	Slopes         Slopes    `json:"slopes"`
+}
+
+// Harness is one configured run, reusable across multiple Run() calls
+// only by reconstructing.
+type Harness struct {
+	scenario Scenario
+	logger   *zap.Logger
+}
+
+// New constructs a Harness for the given scenario. It does not start
+// any work; call Run to drive the scenario.
+func New(scenario Scenario) (*Harness, error) {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		return nil, fmt.Errorf("zap: %w", err)
+	}
+	return &Harness{scenario: scenario, logger: logger}, nil
+}
+
+// Run drives the configured scenario to completion or until the OOM
+// cap is exceeded. It blocks until the run finishes.
+func (h *Harness) Run(ctx context.Context) (Summary, error) {
+	startedAt := time.Now()
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Start fakes for each chain in the scenario using the family registry.
+	fakes := make(map[string]common.FaultableServer)
+	workers := make(map[string]common.Worker)
+	for name, spec := range h.scenario.Chains {
+		family, ok := familyRegistry[spec.Fake]
+		if !ok {
+			return Summary{}, fmt.Errorf("chain %q: no fake family registered for %q", name, spec.Fake)
+		}
+		fakes[name] = family.NewServer(stableChainID(name))
+		workers[name] = family.NewWorker()
+	}
+	defer func() {
+		for _, f := range fakes {
+			f.Stop()
+		}
+	}()
+
+	// Apply each chain's fault schedule on a separate goroutine.
+	for chainName, spec := range h.scenario.Chains {
+		spec := spec
+		chainName := chainName
+		go h.applyFaultSchedule(runCtx, fakes[chainName], spec.FaultSchedule, startedAt)
+	}
+
+	// Launch one worker per chain.
+	var wg sync.WaitGroup
+	for chainName := range h.scenario.Chains {
+		wg.Add(1)
+		fake := fakes[chainName]
+		worker := workers[chainName]
+		go func(_ string) {
+			defer wg.Done()
+			worker.Run(runCtx, fake.URL())
+		}(chainName)
+	}
+
+	// Sample runtime stats on the configured interval.
+	verdict := VerdictOK
+	var samples []Sample
+	var peakRSS uint64
+	var peakGoroutines int
+
+	deadline := time.NewTimer(h.scenario.Duration)
+	defer deadline.Stop()
+	sampleTick := time.NewTicker(h.scenario.SampleInterval)
+	defer sampleTick.Stop()
+
+	// Take an immediate first sample so duration < 2*sample_interval
+	// scenarios still produce a regression input.
+	samples = append(samples, captureSample())
+
+samplingLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			verdict = VerdictAborted
+			break samplingLoop
+		case <-deadline.C:
+			break samplingLoop
+		case <-sampleTick.C:
+			s := captureSample()
+			samples = append(samples, s)
+			if s.RSSBytes > peakRSS {
+				peakRSS = s.RSSBytes
+			}
+			if s.NumGoroutines > peakGoroutines {
+				peakGoroutines = s.NumGoroutines
+			}
+			if h.scenario.OOMCapBytes > 0 && s.RSSBytes >= h.scenario.OOMCapBytes {
+				h.logger.Warn("OOM cap exceeded; aborting scenario",
+					zap.Uint64("rss_bytes", s.RSSBytes),
+					zap.Uint64("cap_bytes", h.scenario.OOMCapBytes))
+				verdict = VerdictKilledOOM
+				break samplingLoop
+			}
+		}
+	}
+
+	cancel()
+	// Bound the worker join so a misbehaving family that ignores
+	// ctx.Done cannot deadlock the harness.
+	joinDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(joinDone)
+	}()
+	select {
+	case <-joinDone:
+	case <-time.After(30 * time.Second):
+		h.logger.Warn("workers did not exit within 30s of cancel; continuing teardown")
+	}
+
+	summary := Summary{
+		Scenario:       h.scenario.Name,
+		Description:    h.scenario.Description,
+		StartedAt:      startedAt,
+		CompletedAt:    time.Now(),
+		SampleCount:    len(samples),
+		Verdict:        verdict,
+		OOMCapBytes:    h.scenario.OOMCapBytes,
+		PeakRSSBytes:   peakRSS,
+		PeakGoroutines: peakGoroutines,
+		Slopes:         ComputeSlopes(samples),
+	}
+	return summary, nil
+}
+
+func (h *Harness) applyFaultSchedule(ctx context.Context, fake common.FaultableServer, schedule []FaultEvent, runStart time.Time) {
+	for _, ev := range schedule {
+		wait := time.Until(runStart.Add(ev.At))
+		if wait > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(wait):
+			}
+		}
+		fake.Set(translateAction(ev.Action))
+	}
+}
+
+func translateAction(a FaultAction) common.Fault {
+	switch a {
+	case FaultClose, FaultDisconnect:
+		return common.FaultCloseAllConnections
+	case FaultMalformed:
+		return common.FaultMalformed
+	case FaultSlow:
+		return common.FaultSlow
+	case FaultFreeze:
+		return common.FaultStuck
+	case FaultHeal:
+		return common.FaultNone
+	default:
+		return common.FaultNone
+	}
+}
+
+func captureSample() Sample {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	rss := currentRSSBytes()
+	return Sample{
+		At:             time.Now(),
+		RSSBytes:       rss,
+		HeapInuseBytes: ms.HeapInuse,
+		NumGoroutines:  runtime.NumGoroutine(),
+		OpenFDs:        currentFDCount(),
+	}
+}
+
+// currentRSSBytes reads /proc/self/status on Linux or falls back to
+// HeapSys on other platforms. The fallback is imprecise but works for
+// the macOS dev path.
+func currentRSSBytes() uint64 {
+	data, err := os.ReadFile("/proc/self/status")
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(line, "VmRSS:") {
+				var kb uint64
+				if _, err := fmt.Sscanf(line, "VmRSS: %d kB", &kb); err == nil {
+					return kb * 1024
+				}
+			}
+		}
+	}
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return ms.Sys
+}
+
+// currentFDCount counts entries in /proc/self/fd on Linux, returns 0
+// elsewhere. The slope is what matters, not the absolute count.
+func currentFDCount() int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0
+	}
+	return len(entries)
+}
+
+// stableChainID hashes the chain name into a deterministic uint32-sized
+// value. The collisions don't matter — each fake only needs to match
+// against its own dial.
+func stableChainID(name string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	return h.Sum64() & 0xffffffff
+}
+
+// WriteSummary dumps a Summary to a JSON file at `path`, creating parent
+// dirs as needed.
+func WriteSummary(path string, s Summary) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+

--- a/node/hack/leakharness/harness/harness.go
+++ b/node/hack/leakharness/harness/harness.go
@@ -64,6 +64,19 @@ type Summary struct {
 	PeakRSSBytes   uint64    `json:"peak_rss_bytes"`
 	PeakGoroutines int       `json:"peak_goroutines"`
 	Slopes         Slopes    `json:"slopes"`
+	// Profiles, when present, holds the relative paths to pprof
+	// profiles captured at scenario start and end. Empty when the
+	// harness was constructed without a ProfileDir.
+	Profiles ProfilePaths `json:"profiles,omitempty"`
+}
+
+// ProfilePaths records the relative paths of pprof profiles captured
+// during a Run.
+type ProfilePaths struct {
+	HeapStart      string `json:"heap_start,omitempty"`
+	HeapEnd        string `json:"heap_end,omitempty"`
+	GoroutineStart string `json:"goroutine_start,omitempty"`
+	GoroutineEnd   string `json:"goroutine_end,omitempty"`
 }
 
 // Harness is one configured run, reusable across multiple Run() calls
@@ -71,6 +84,13 @@ type Summary struct {
 type Harness struct {
 	scenario Scenario
 	logger   *zap.Logger
+
+	// ProfileDir, when non-empty, causes Run() to write heap and
+	// goroutine pprof profiles at scenario start and end. The
+	// resulting `heap-start.pprof` / `heap-end.pprof` pair is the
+	// fastest way to localise an allocation regression:
+	//   go tool pprof -base heap-start.pprof heap-end.pprof
+	ProfileDir string
 }
 
 // New constructs a Harness for the given scenario. It does not start
@@ -89,6 +109,28 @@ func (h *Harness) Run(ctx context.Context) (Summary, error) {
 	startedAt := time.Now()
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	// Capture a baseline heap+goroutine profile before any workers
+	// start. The operator diffs this against the end-of-run profile to
+	// localise allocation sites.
+	var profiles ProfilePaths
+	if h.ProfileDir != "" {
+		if err := os.MkdirAll(h.ProfileDir, 0o755); err != nil {
+			return Summary{}, fmt.Errorf("mkdir profile dir: %w", err)
+		}
+		heapStart := filepath.Join(h.ProfileDir, "heap-start.pprof")
+		grStart := filepath.Join(h.ProfileDir, "goroutine-start.pprof")
+		if err := CaptureHeap(heapStart); err != nil {
+			h.logger.Warn("failed to capture start heap profile", zap.Error(err))
+		} else {
+			profiles.HeapStart = "heap-start.pprof"
+		}
+		if err := CaptureGoroutine(grStart); err != nil {
+			h.logger.Warn("failed to capture start goroutine profile", zap.Error(err))
+		} else {
+			profiles.GoroutineStart = "goroutine-start.pprof"
+		}
+	}
 
 	// Start fakes for each chain in the scenario using the family registry.
 	fakes := make(map[string]common.FaultableServer)
@@ -182,6 +224,24 @@ samplingLoop:
 		h.logger.Warn("workers did not exit within 30s of cancel; continuing teardown")
 	}
 
+	// End-of-run profiles. Captured after workers exit so the snapshot
+	// reflects steady-state allocations attributable to the workload,
+	// not in-flight ones.
+	if h.ProfileDir != "" {
+		heapEnd := filepath.Join(h.ProfileDir, "heap-end.pprof")
+		grEnd := filepath.Join(h.ProfileDir, "goroutine-end.pprof")
+		if err := CaptureHeap(heapEnd); err != nil {
+			h.logger.Warn("failed to capture end heap profile", zap.Error(err))
+		} else {
+			profiles.HeapEnd = "heap-end.pprof"
+		}
+		if err := CaptureGoroutine(grEnd); err != nil {
+			h.logger.Warn("failed to capture end goroutine profile", zap.Error(err))
+		} else {
+			profiles.GoroutineEnd = "goroutine-end.pprof"
+		}
+	}
+
 	summary := Summary{
 		Scenario:       h.scenario.Name,
 		Description:    h.scenario.Description,
@@ -193,6 +253,7 @@ samplingLoop:
 		PeakRSSBytes:   peakRSS,
 		PeakGoroutines: peakGoroutines,
 		Slopes:         ComputeSlopes(samples),
+		Profiles:       profiles,
 	}
 	return summary, nil
 }

--- a/node/hack/leakharness/harness/harness_e2e_test.go
+++ b/node/hack/leakharness/harness/harness_e2e_test.go
@@ -1,0 +1,126 @@
+package harness_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMezoFlapCompressed runs an abbreviated version of the mezo_flap
+// scenario (20 s instead of 5 min) to verify the full pipeline:
+// scenario load -> fakes start -> fault schedule applied ->
+// connectors dial/close in a loop -> samples gathered -> slopes computed.
+// The full 5-minute soak is for operators; this test is the CI smoke.
+//
+// This is the teeth test for the EVM connector restart leak (commit
+// 6813f4aa). If `EthereumBaseConnector.Close()` regresses, every
+// worker iteration strands ~3 goroutines; over ~150 cycles in 20 s
+// that produces a slope well above the assertion bound below.
+func TestMezoFlapCompressed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("E2E harness test skipped in -short")
+	}
+
+	scenario := harness.Scenario{
+		Name:           "mezo_flap_compressed",
+		Description:    "compressed mezo_flap variant for unit-test pipelines",
+		Duration:       20 * time.Second,
+		SampleInterval: 2 * time.Second,
+		OOMCapBytes:    6 << 30,
+		Chains: map[string]harness.ChainSpec{
+			"sepolia": {
+				Fake:      harness.FakeEVM,
+				Behaviour: harness.BehaviourFlapping,
+				FaultSchedule: []harness.FaultEvent{
+					{At: 3 * time.Second, Action: harness.FaultClose},
+					{At: 4 * time.Second, Action: harness.FaultHeal},
+					{At: 8 * time.Second, Action: harness.FaultClose},
+					{At: 9 * time.Second, Action: harness.FaultHeal},
+					{At: 13 * time.Second, Action: harness.FaultClose},
+					{At: 14 * time.Second, Action: harness.FaultHeal},
+				},
+			},
+		},
+	}
+
+	h, err := harness.New(scenario)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	summary, err := h.Run(ctx)
+	require.NoError(t, err)
+
+	require.NotEqual(t, harness.VerdictKilledOOM, summary.Verdict,
+		"OOM cap hit during compressed run: %+v", summary)
+	require.Equal(t, harness.VerdictOK, summary.Verdict)
+	require.GreaterOrEqual(t, summary.SampleCount, 5, "need at least 5 samples for stable regression")
+
+	// Teeth: with Close() working, goroutine slope under fault-driven
+	// restart should be modest. Pre-fix code (no Close) leaked ~3
+	// goroutines per ~100 ms cycle, producing slopes in the hundreds
+	// per minute. We assert under 5000/h, which a real leak would
+	// blow past while accommodating GC/scheduler noise in 20 s.
+	require.Less(t, summary.Slopes.GoroutinesPerHour, 5000.0,
+		"goroutine slope %.1f/h suggests connector dispatch goroutines are leaking",
+		summary.Slopes.GoroutinesPerHour)
+
+	t.Logf("mezo_flap_compressed summary: peak_rss=%d MiB, peak_goroutines=%d, rss_slope=%.2f MB/h, gr_slope=%.2f /h",
+		summary.PeakRSSBytes>>20, summary.PeakGoroutines,
+		summary.Slopes.RSSMBPerHour, summary.Slopes.GoroutinesPerHour)
+}
+
+// TestMultiChainFlapCompressed exercises the family-registry dispatch
+// path with more than one chain in the scenario. Pins the multi-chain
+// scenario YAML and verifies fakes from different families both receive
+// traffic.
+func TestMultiChainFlapCompressed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("E2E harness test skipped in -short")
+	}
+
+	scenario := harness.Scenario{
+		Name:           "multi_chain_flap_compressed",
+		Description:    "compressed multi-chain variant",
+		Duration:       12 * time.Second,
+		SampleInterval: 3 * time.Second,
+		OOMCapBytes:    6 << 30,
+		Chains: map[string]harness.ChainSpec{
+			"sepolia": {
+				Fake:      harness.FakeEVM,
+				Behaviour: harness.BehaviourFlapping,
+				FaultSchedule: []harness.FaultEvent{
+					{At: 4 * time.Second, Action: harness.FaultClose},
+					{At: 5 * time.Second, Action: harness.FaultHeal},
+				},
+			},
+			"sui": {
+				Fake:      harness.FakeSui,
+				Behaviour: harness.BehaviourFlapping,
+				FaultSchedule: []harness.FaultEvent{
+					{At: 6 * time.Second, Action: harness.FaultClose},
+					{At: 7 * time.Second, Action: harness.FaultHeal},
+				},
+			},
+		},
+	}
+
+	h, err := harness.New(scenario)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	summary, err := h.Run(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, harness.VerdictOK, summary.Verdict)
+	require.GreaterOrEqual(t, summary.SampleCount, 3)
+
+	t.Logf("multi_chain_flap_compressed: peak_rss=%d MiB, peak_goroutines=%d",
+		summary.PeakRSSBytes>>20, summary.PeakGoroutines)
+}

--- a/node/hack/leakharness/harness/harness_test.go
+++ b/node/hack/leakharness/harness/harness_test.go
@@ -1,0 +1,51 @@
+// Package harness contains the leak-detection harness orchestrator.
+//
+// This test file is Phase 0 of the plan at
+// `.claude/tasks/guardian-leak-harness.md`. It expresses the public API
+// contract that Phase 1 must satisfy. On Phase 0 the harness package
+// has no implementation, so this test fails to build — that compile
+// failure is the failing red bar TDD requires.
+package harness_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSteadyStateOnHEAD runs the steady-state scenario against the
+// current guardiand HEAD and asserts that the harness completes without
+// hitting the 6 GiB OOM cap. It does NOT assert any slope bound — the
+// harness is report-only by decision #6 of the plan; the slopes are
+// logged so an operator can eyeball them.
+func TestSteadyStateOnHEAD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("leakharness E2E test takes minutes; skipped in -short")
+	}
+
+	scenario, err := harness.LoadScenario("../scenarios/steady_state.yaml")
+	require.NoError(t, err, "loading scenario yaml")
+
+	// Allow scenario.Duration plus generous slack for guardiand build,
+	// boot, scrape settling and teardown.
+	ctx, cancel := context.WithTimeout(context.Background(), scenario.Duration+2*time.Minute)
+	defer cancel()
+
+	h, err := harness.New(scenario)
+	require.NoError(t, err, "constructing harness")
+
+	summary, err := h.Run(ctx)
+	require.NoError(t, err, "running harness")
+
+	require.NotEqual(t, harness.VerdictKilledOOM, summary.Verdict,
+		"guardiand hit 6 GiB RSS cap during steady-state scenario; slopes captured up to kill: %+v", summary.Slopes)
+
+	t.Logf("steady-state slopes — RSS: %.2f MB/h, heap_inuse: %.2f MB/h, goroutines: %.2f/h, fds: %.2f/h",
+		summary.Slopes.RSSMBPerHour,
+		summary.Slopes.HeapInuseMBPerHour,
+		summary.Slopes.GoroutinesPerHour,
+		summary.Slopes.FDsPerHour)
+}

--- a/node/hack/leakharness/harness/pprof.go
+++ b/node/hack/leakharness/harness/pprof.go
@@ -1,0 +1,79 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // side-effect: registers /debug/pprof/* on http.DefaultServeMux
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"time"
+)
+
+// CaptureHeap writes an inuse-memory heap profile to `path`. Forces a
+// GC first so the profile reflects truly-reachable allocations rather
+// than as-yet-uncollected garbage. The resulting file is gzipped
+// protobuf consumable by `go tool pprof`.
+func CaptureHeap(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %q: %w", path, err)
+	}
+	defer f.Close()
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("WriteHeapProfile %q: %w", path, err)
+	}
+	return nil
+}
+
+// CaptureGoroutine writes a goroutine stack profile to `path`. The
+// pprof debug level is 0 so the output is the compact protobuf form,
+// suitable for `go tool pprof`.
+func CaptureGoroutine(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %q: %w", path, err)
+	}
+	defer f.Close()
+	prof := pprof.Lookup("goroutine")
+	if prof == nil {
+		return fmt.Errorf("no goroutine profile registered")
+	}
+	if err := prof.WriteTo(f, 0); err != nil {
+		return fmt.Errorf("WriteTo %q: %w", path, err)
+	}
+	return nil
+}
+
+// StartPprofServer brings up `net/http/pprof` on the given address.
+// Bind to a loopback address — anything else exposes a heap dump
+// (potential signing-key leak) and a DoS surface to the network.
+// Returns a stop function that gracefully shuts the server down with
+// a 5-second deadline. If `addr` is empty, this is a no-op and stop
+// is harmless.
+func StartPprofServer(addr string) (stop func() error, actualAddr string, err error) {
+	if addr == "" {
+		return func() error { return nil }, "", nil
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, "", fmt.Errorf("listen %q: %w", addr, err)
+	}
+	srv := &http.Server{
+		Handler:      nil, // use http.DefaultServeMux where net/http/pprof registered
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 60 * time.Second, // pprof CPU profile dumps can be slow
+	}
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+	stop = func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(ctx)
+	}
+	return stop, ln.Addr().String(), nil
+}

--- a/node/hack/leakharness/harness/pprof_test.go
+++ b/node/hack/leakharness/harness/pprof_test.go
@@ -1,0 +1,67 @@
+package harness
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureHeap_WritesNonEmptyGzippedProfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "heap.pprof")
+
+	require.NoError(t, CaptureHeap(path))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0, "heap profile must be non-empty")
+	// pprof profiles are gzip-compressed protobufs; verify the magic
+	// bytes so we know we wrote a valid file, not just an empty stub.
+	require.GreaterOrEqual(t, len(data), 2)
+	require.Equal(t, byte(0x1f), data[0], "gzip magic byte 0")
+	require.Equal(t, byte(0x8b), data[1], "gzip magic byte 1")
+}
+
+func TestCaptureGoroutine_WritesNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "goroutine.pprof")
+
+	require.NoError(t, CaptureGoroutine(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0), "goroutine profile must be non-empty")
+}
+
+func TestStartPprofServer_DisabledIsNoop(t *testing.T) {
+	stop, addr, err := StartPprofServer("")
+	require.NoError(t, err)
+	require.Empty(t, addr)
+	require.NotNil(t, stop)
+	require.NoError(t, stop())
+}
+
+func TestStartPprofServer_ServesHeapAndGoroutine(t *testing.T) {
+	// 127.0.0.1:0 -> kernel assigns a free ephemeral port so the test
+	// is resilient to a developer already running pprof on :6061.
+	stop, addr, err := StartPprofServer("127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stop())
+	}()
+	require.True(t, strings.HasPrefix(addr, "127.0.0.1:"), "should bind localhost, got %q", addr)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	for _, profile := range []string{"heap", "goroutine"} {
+		resp, err := client.Get("http://" + addr + "/debug/pprof/" + profile)
+		require.NoError(t, err, profile)
+		require.Equal(t, http.StatusOK, resp.StatusCode, profile)
+		_ = resp.Body.Close()
+	}
+}

--- a/node/hack/leakharness/harness/scenario.go
+++ b/node/hack/leakharness/harness/scenario.go
@@ -1,0 +1,200 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Behaviour names a fake-RPC operating mode. Phase 1 ships only
+// "healthy"; Phase 2 adds "flapping", "slow", "stuck", "malformed".
+type Behaviour string
+
+const (
+	BehaviourHealthy   Behaviour = "healthy"
+	BehaviourFlapping  Behaviour = "flapping"
+	BehaviourSlow      Behaviour = "slow"
+	BehaviourStuck     Behaviour = "stuck"
+	BehaviourMalformed Behaviour = "malformed"
+)
+
+// FakeKind names the fake-RPC family for a chain.
+type FakeKind string
+
+const (
+	FakeEVM      FakeKind = "evm"
+	FakeSui      FakeKind = "sui"
+	FakeCosmwasm FakeKind = "cosmwasm"
+	FakeXRPL     FakeKind = "xrpl"
+)
+
+// FaultAction is a single discrete fault to inject at a specific
+// scenario time. Phase 1 declares the schema but only "noop" is wired.
+type FaultAction string
+
+const (
+	FaultClose      FaultAction = "close_websockets"
+	FaultHeal       FaultAction = "heal"
+	FaultFreeze     FaultAction = "freeze_heights"
+	FaultMalformed  FaultAction = "return_malformed"
+	FaultSlow       FaultAction = "slow_response"
+	FaultDisconnect FaultAction = "disconnect"
+)
+
+type FaultEvent struct {
+	At     time.Duration `yaml:"at"`
+	Action FaultAction   `yaml:"action"`
+}
+
+type ChainSpec struct {
+	Fake          FakeKind     `yaml:"fake"`
+	Behaviour     Behaviour    `yaml:"behaviour"`
+	FaultSchedule []FaultEvent `yaml:"fault_schedule,omitempty"`
+}
+
+type GuardianSpec struct {
+	UnsafeDevMode bool     `yaml:"unsafe_dev_mode"`
+	EnabledChains []string `yaml:"enabled_chains"`
+	Signer        string   `yaml:"signer"`
+	ExtraFlags    []string `yaml:"extra_flags"`
+}
+
+type SlopeReport struct {
+	RSSMBPerHour       bool `yaml:"rss_mb_per_hour"`
+	HeapInuseMBPerHour bool `yaml:"heap_inuse_mb_per_hour"`
+	GoroutinesPerHour  bool `yaml:"goroutines_per_hour"`
+	FDsPerHour         bool `yaml:"fds_per_hour"`
+}
+
+// Scenario is the full parsed scenario. The Defaults string references
+// a sibling YAML whose top-level fields are merged in if the scenario
+// itself does not set them.
+type Scenario struct {
+	Name           string               `yaml:"name"`
+	Description    string               `yaml:"description"`
+	Duration       time.Duration        `yaml:"duration"`
+	SampleInterval time.Duration        `yaml:"sample_interval"`
+	Guardian       GuardianSpec         `yaml:"guardian"`
+	OOMCapBytes    uint64               `yaml:"oom_cap_bytes"`
+	SlopeReport    SlopeReport          `yaml:"slope_report"`
+	Defaults       string               `yaml:"defaults"`
+	Chains         map[string]ChainSpec `yaml:"chains"`
+}
+
+// LoadScenario reads `path` and, if it declares a `defaults:` field,
+// merges the sibling defaults file into any fields the scenario itself
+// did not set. The defaults file is resolved relative to `path`.
+func LoadScenario(path string) (Scenario, error) {
+	primary, err := readScenarioFile(path)
+	if err != nil {
+		return Scenario{}, err
+	}
+
+	if primary.Defaults == "" {
+		return primary, validate(primary)
+	}
+
+	defaultsPath := filepath.Join(filepath.Dir(path), primary.Defaults)
+	defaults, err := readScenarioFile(defaultsPath)
+	if err != nil {
+		return Scenario{}, fmt.Errorf("loading defaults %q: %w", defaultsPath, err)
+	}
+
+	merged := mergeScenarios(defaults, primary)
+	return merged, validate(merged)
+}
+
+func readScenarioFile(path string) (Scenario, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Scenario{}, fmt.Errorf("reading %q: %w", path, err)
+	}
+	var s Scenario
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return Scenario{}, fmt.Errorf("parsing %q: %w", path, err)
+	}
+	return s, nil
+}
+
+// mergeScenarios overlays `primary` onto `defaults`. Any field set on
+// `primary` wins; otherwise the value from `defaults` is used.
+//
+// Caveat: the merge treats Go zero values as "unset". A scenario that
+// intentionally sets a bool to false or a duration to zero cannot
+// override a non-zero default. This is acceptable for the current
+// schema (no scenario wants to disable a default flag) but should be
+// revisited if knobs like `unsafe_dev_mode: false` ever become
+// load-bearing — at that point switch the affected fields to *bool /
+// *time.Duration pointers.
+func mergeScenarios(defaults, primary Scenario) Scenario {
+	out := defaults
+
+	if primary.Name != "" {
+		out.Name = primary.Name
+	}
+	if primary.Description != "" {
+		out.Description = primary.Description
+	}
+	if primary.Duration != 0 {
+		out.Duration = primary.Duration
+	}
+	if primary.SampleInterval != 0 {
+		out.SampleInterval = primary.SampleInterval
+	}
+	if primary.OOMCapBytes != 0 {
+		out.OOMCapBytes = primary.OOMCapBytes
+	}
+	// Guardian: any non-zero field on primary wins.
+	if primary.Guardian.UnsafeDevMode {
+		out.Guardian.UnsafeDevMode = true
+	}
+	if len(primary.Guardian.EnabledChains) > 0 {
+		out.Guardian.EnabledChains = primary.Guardian.EnabledChains
+	}
+	if primary.Guardian.Signer != "" {
+		out.Guardian.Signer = primary.Guardian.Signer
+	}
+	if len(primary.Guardian.ExtraFlags) > 0 {
+		out.Guardian.ExtraFlags = primary.Guardian.ExtraFlags
+	}
+	// SlopeReport: bools, if any primary bool is set, the whole struct
+	// is overridden. Simpler than fine-grained merge.
+	if primary.SlopeReport != (SlopeReport{}) {
+		out.SlopeReport = primary.SlopeReport
+	}
+	if len(primary.Chains) > 0 {
+		out.Chains = primary.Chains
+	}
+	return out
+}
+
+func validate(s Scenario) error {
+	if s.Name == "" {
+		return fmt.Errorf("scenario.name is required")
+	}
+	if s.Duration <= 0 {
+		return fmt.Errorf("scenario.duration must be > 0")
+	}
+	if s.SampleInterval <= 0 {
+		return fmt.Errorf("scenario.sample_interval must be > 0 (defaults file may not have been merged)")
+	}
+	if s.OOMCapBytes == 0 {
+		return fmt.Errorf("scenario.oom_cap_bytes must be > 0")
+	}
+	if len(s.Chains) == 0 {
+		return fmt.Errorf("scenario.chains must declare at least one chain")
+	}
+	for name, c := range s.Chains {
+		if c.Fake == "" {
+			return fmt.Errorf("chains[%s].fake is required", name)
+		}
+		if c.Behaviour == "" {
+			return fmt.Errorf("chains[%s].behaviour is required", name)
+		}
+	}
+	return nil
+}
+

--- a/node/hack/leakharness/harness/scenario_test.go
+++ b/node/hack/leakharness/harness/scenario_test.go
@@ -1,0 +1,83 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadScenario_MergesDefaults(t *testing.T) {
+	tmp := t.TempDir()
+
+	defaultsYAML := []byte(`sample_interval: 30s
+guardian:
+  enabled_chains: [sepolia]
+oom_cap_bytes: 6442450944
+slope_report:
+  rss_mb_per_hour: true
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "_defaults.yaml"), defaultsYAML, 0o644))
+
+	scenarioYAML := []byte(`name: example
+description: a test scenario
+duration: 30s
+defaults: _defaults.yaml
+chains:
+  sepolia:
+    fake: evm
+    behaviour: healthy
+`)
+	scenarioPath := filepath.Join(tmp, "example.yaml")
+	require.NoError(t, os.WriteFile(scenarioPath, scenarioYAML, 0o644))
+
+	scenario, err := LoadScenario(scenarioPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "example", scenario.Name)
+	require.Equal(t, 30*time.Second, scenario.Duration)
+	require.Equal(t, 30*time.Second, scenario.SampleInterval, "sample_interval should come from defaults")
+	require.Equal(t, uint64(6442450944), scenario.OOMCapBytes, "oom_cap_bytes should come from defaults")
+	require.Equal(t, []string{"sepolia"}, scenario.Guardian.EnabledChains)
+	require.True(t, scenario.SlopeReport.RSSMBPerHour)
+	require.Len(t, scenario.Chains, 1)
+}
+
+func TestLoadScenario_RejectsMissingFields(t *testing.T) {
+	tmp := t.TempDir()
+
+	scenarioYAML := []byte(`name: malformed
+duration: 30s
+chains:
+  sepolia:
+    fake: evm
+    behaviour: healthy
+`)
+	path := filepath.Join(tmp, "bad.yaml")
+	require.NoError(t, os.WriteFile(path, scenarioYAML, 0o644))
+
+	_, err := LoadScenario(path)
+	require.Error(t, err, "missing sample_interval should fail validation")
+}
+
+func TestLoadScenario_RealSteadyStateYAML(t *testing.T) {
+	// Exercise the actual scenarios/steady_state.yaml shipped in the
+	// harness so a typo there fails this test, not the long E2E run.
+	scenario, err := LoadScenario("../scenarios/steady_state.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "steady_state", scenario.Name)
+	require.True(t, scenario.Duration > 0)
+	require.True(t, scenario.SampleInterval > 0)
+	require.True(t, scenario.OOMCapBytes > 0)
+	require.NotEmpty(t, scenario.Chains)
+}
+
+func TestLoadScenario_RealMezoFlapYAML(t *testing.T) {
+	scenario, err := LoadScenario("../scenarios/mezo_flap.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "mezo_flap", scenario.Name)
+	require.Equal(t, 5*time.Minute, scenario.Duration)
+	require.NotEmpty(t, scenario.Chains["sepolia"].FaultSchedule)
+}

--- a/node/hack/leakharness/harness/slope.go
+++ b/node/hack/leakharness/harness/slope.go
@@ -1,0 +1,73 @@
+package harness
+
+import "time"
+
+// Sample is one observation at a point in time.
+type Sample struct {
+	At              time.Time
+	RSSBytes        uint64
+	HeapInuseBytes  uint64
+	NumGoroutines   int
+	OpenFDs         int
+}
+
+// Slopes carries the per-hour rate of change for each tracked metric,
+// derived by ordinary-least-squares linear regression of each metric
+// against time.
+type Slopes struct {
+	RSSMBPerHour       float64
+	HeapInuseMBPerHour float64
+	GoroutinesPerHour  float64
+	FDsPerHour         float64
+}
+
+// ComputeSlopes returns the per-hour slope for each metric. If fewer
+// than two samples are present, every slope is zero (linear regression
+// is undefined with one point).
+func ComputeSlopes(samples []Sample) Slopes {
+	if len(samples) < 2 {
+		return Slopes{}
+	}
+
+	t0 := samples[0].At
+	xs := make([]float64, len(samples))
+	for i, s := range samples {
+		xs[i] = s.At.Sub(t0).Hours()
+	}
+
+	const bytesPerMB = 1024.0 * 1024.0
+
+	return Slopes{
+		RSSMBPerHour:       fitSlope(xs, mapBytes(samples, func(s Sample) float64 { return float64(s.RSSBytes) / bytesPerMB })),
+		HeapInuseMBPerHour: fitSlope(xs, mapBytes(samples, func(s Sample) float64 { return float64(s.HeapInuseBytes) / bytesPerMB })),
+		GoroutinesPerHour:  fitSlope(xs, mapBytes(samples, func(s Sample) float64 { return float64(s.NumGoroutines) })),
+		FDsPerHour:         fitSlope(xs, mapBytes(samples, func(s Sample) float64 { return float64(s.OpenFDs) })),
+	}
+}
+
+func mapBytes(samples []Sample, f func(Sample) float64) []float64 {
+	out := make([]float64, len(samples))
+	for i, s := range samples {
+		out[i] = f(s)
+	}
+	return out
+}
+
+// fitSlope returns the slope of an ordinary least-squares regression
+// of ys on xs. xs and ys must have the same length and at least two
+// distinct x values.
+func fitSlope(xs, ys []float64) float64 {
+	n := float64(len(xs))
+	var sumX, sumY, sumXY, sumXX float64
+	for i := range xs {
+		sumX += xs[i]
+		sumY += ys[i]
+		sumXY += xs[i] * ys[i]
+		sumXX += xs[i] * xs[i]
+	}
+	denom := n*sumXX - sumX*sumX
+	if denom == 0 {
+		return 0
+	}
+	return (n*sumXY - sumX*sumY) / denom
+}

--- a/node/hack/leakharness/harness/slope.go
+++ b/node/hack/leakharness/harness/slope.go
@@ -15,10 +15,10 @@ type Sample struct {
 // derived by ordinary-least-squares linear regression of each metric
 // against time.
 type Slopes struct {
-	RSSMBPerHour       float64
-	HeapInuseMBPerHour float64
-	GoroutinesPerHour  float64
-	FDsPerHour         float64
+	RSSMBPerHour       float64 `json:"rss_mb_per_hour"`
+	HeapInuseMBPerHour float64 `json:"heap_inuse_mb_per_hour"`
+	GoroutinesPerHour  float64 `json:"goroutines_per_hour"`
+	FDsPerHour         float64 `json:"fds_per_hour"`
 }
 
 // ComputeSlopes returns the per-hour slope for each metric. If fewer

--- a/node/hack/leakharness/harness/slope_test.go
+++ b/node/hack/leakharness/harness/slope_test.go
@@ -1,0 +1,42 @@
+package harness
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeSlopes_FewerThanTwoSamples(t *testing.T) {
+	require.Equal(t, Slopes{}, ComputeSlopes(nil))
+	require.Equal(t, Slopes{}, ComputeSlopes([]Sample{{}}))
+}
+
+func TestComputeSlopes_LinearGrowth(t *testing.T) {
+	// 100 MiB/h RSS growth, exactly linear, over 1 hour at 1-minute steps.
+	t0 := time.Now()
+	const stepBytes = 100 * 1024 * 1024 / 60 // ~1.67 MiB per minute
+	samples := make([]Sample, 0, 61)
+	for i := 0; i <= 60; i++ {
+		samples = append(samples, Sample{
+			At:       t0.Add(time.Duration(i) * time.Minute),
+			RSSBytes: uint64(i) * stepBytes,
+		})
+	}
+	slopes := ComputeSlopes(samples)
+	// stepBytes/min * 60min = ~100 MiB/h; allow a 1% tolerance for
+	// integer truncation in stepBytes.
+	require.InDelta(t, 100.0, slopes.RSSMBPerHour, 1.0, "slope should be ~100 MiB/h")
+}
+
+func TestComputeSlopes_ConstantSeries(t *testing.T) {
+	t0 := time.Now()
+	samples := []Sample{
+		{At: t0, RSSBytes: 1_000_000_000},
+		{At: t0.Add(time.Minute), RSSBytes: 1_000_000_000},
+		{At: t0.Add(2 * time.Minute), RSSBytes: 1_000_000_000},
+	}
+	slopes := ComputeSlopes(samples)
+	require.True(t, math.Abs(slopes.RSSMBPerHour) < 0.0001, "flat series must yield ~0 slope, got %f", slopes.RSSMBPerHour)
+}

--- a/node/hack/leakharness/harness/translate_test.go
+++ b/node/hack/leakharness/harness/translate_test.go
@@ -1,0 +1,33 @@
+package harness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/certusone/wormhole/node/hack/leakharness/fakerpc/common"
+)
+
+// TestTranslateAction pins the YAML-FaultAction-to-internal-Fault
+// mapping. If anyone refactors translateAction and inverts two cases
+// (a real human-error class), this fires.
+func TestTranslateAction(t *testing.T) {
+	cases := []struct {
+		in   FaultAction
+		want common.Fault
+	}{
+		{FaultClose, common.FaultCloseAllConnections},
+		{FaultDisconnect, common.FaultCloseAllConnections},
+		{FaultMalformed, common.FaultMalformed},
+		{FaultSlow, common.FaultSlow},
+		{FaultFreeze, common.FaultStuck},
+		{FaultHeal, common.FaultNone},
+		{FaultAction("unknown"), common.FaultNone},
+		{FaultAction(""), common.FaultNone},
+	}
+	for _, c := range cases {
+		t.Run(string(c.in), func(t *testing.T) {
+			require.Equal(t, c.want, translateAction(c.in))
+		})
+	}
+}

--- a/node/hack/leakharness/scenarios/_defaults.yaml
+++ b/node/hack/leakharness/scenarios/_defaults.yaml
@@ -1,0 +1,27 @@
+# Shared scenario defaults. Individual scenario files reference this via
+# `defaults: _defaults.yaml` and override only the fields they need to.
+
+sample_interval: 30s
+
+guardian:
+  unsafe_dev_mode: true
+  # Minimum set of chains needed to exercise the EVM watcher restart
+  # path. Phase 3 will extend this once the sui / cosmwasm / xrpl fakes
+  # land.
+  enabled_chains:
+    - sepolia
+  signer: file:devkeys/01.priv
+  extra_flags: []
+
+# 6 GiB matches the production GOMEMLIMIT on vm-guardian-01. Exceeding
+# this is the only hard failure mode of the harness; everything else is
+# reported, not gated.
+oom_cap_bytes: 6442450944
+
+# Per decision #6: report all slopes, gate on none. Operator reads
+# summary.json.
+slope_report:
+  rss_mb_per_hour: true
+  heap_inuse_mb_per_hour: true
+  goroutines_per_hour: true
+  fds_per_hour: true

--- a/node/hack/leakharness/scenarios/mezo_flap.yaml
+++ b/node/hack/leakharness/scenarios/mezo_flap.yaml
@@ -1,0 +1,42 @@
+name: mezo_flap
+description: |
+  Reproduces the mezo testnet flap observed on 2026-05-27.
+  The single configured chain disconnects all its WebSocket clients
+  every 30 seconds and heals 1 second later, forcing the watcher's
+  supervisor to restart the connector roughly every 30 seconds.
+
+  On the pre-fix code (parent commit 9401d4df) this scenario produced
+  ~75-160 MB/h RSS slope on the testnet guardian. With 6813f4aa the
+  slope should drop to near zero. This is the regression-detection
+  scenario.
+
+defaults: _defaults.yaml
+
+# 5 minutes captures roughly 10 restart cycles, enough for the slope
+# to stabilise above noise.
+duration: 5m
+sample_interval: 15s
+
+chains:
+  sepolia:
+    fake: evm
+    behaviour: flapping
+    fault_schedule:
+      - { at: 30s,   action: close_websockets }
+      - { at: 31s,   action: heal }
+      - { at: 60s,   action: close_websockets }
+      - { at: 61s,   action: heal }
+      - { at: 90s,   action: close_websockets }
+      - { at: 91s,   action: heal }
+      - { at: 120s,  action: close_websockets }
+      - { at: 121s,  action: heal }
+      - { at: 150s,  action: close_websockets }
+      - { at: 151s,  action: heal }
+      - { at: 180s,  action: close_websockets }
+      - { at: 181s,  action: heal }
+      - { at: 210s,  action: close_websockets }
+      - { at: 211s,  action: heal }
+      - { at: 240s,  action: close_websockets }
+      - { at: 241s,  action: heal }
+      - { at: 270s,  action: close_websockets }
+      - { at: 271s,  action: heal }

--- a/node/hack/leakharness/scenarios/multi_chain_flap.yaml
+++ b/node/hack/leakharness/scenarios/multi_chain_flap.yaml
@@ -1,0 +1,32 @@
+name: multi_chain_flap
+description: |
+  Mixed-family scenario: an EVM chain and a Sui chain both flapping out
+  of phase. Exercises the harness's family-registry dispatch and
+  surfaces any per-family leak shape.
+
+defaults: _defaults.yaml
+
+duration: 3m
+sample_interval: 15s
+
+chains:
+  sepolia:
+    fake: evm
+    behaviour: flapping
+    fault_schedule:
+      - { at: 20s,  action: close_websockets }
+      - { at: 21s,  action: heal }
+      - { at: 60s,  action: close_websockets }
+      - { at: 61s,  action: heal }
+      - { at: 120s, action: close_websockets }
+      - { at: 121s, action: heal }
+  sui:
+    fake: sui
+    behaviour: flapping
+    fault_schedule:
+      - { at: 40s,  action: close_websockets }
+      - { at: 41s,  action: heal }
+      - { at: 80s,  action: close_websockets }
+      - { at: 81s,  action: heal }
+      - { at: 140s, action: close_websockets }
+      - { at: 141s, action: heal }

--- a/node/hack/leakharness/scenarios/steady_state.yaml
+++ b/node/hack/leakharness/scenarios/steady_state.yaml
@@ -1,0 +1,18 @@
+name: steady_state
+description: |
+  All enabled chains return healthy responses for the duration of the
+  run. Baseline slope should be near zero. Acts as the smoke test for
+  the harness itself: if this run sees non-trivial slope on a quiet
+  guardiand, the orchestrator or the fake RPCs are misbehaving.
+
+defaults: _defaults.yaml
+
+# 60 seconds is enough for ~2 metric scrapes at the default 30 s
+# interval, which is the minimum sample count for a linear regression
+# to be meaningful. Soak variants override this.
+duration: 60s
+
+chains:
+  sepolia:
+    fake: evm
+    behaviour: healthy

--- a/node/hack/leakharness/scripts/nightly.sh
+++ b/node/hack/leakharness/scripts/nightly.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# nightly.sh — run every shipped scenario back-to-back and emit a
+# tabular slope summary. Suitable for cron on a dev box; not for CI.
+#
+# Output layout:
+#   $RUN_ROOT/<scenario>-<ts>/summary.json
+#   $RUN_ROOT/<scenario>-<ts>/console.log
+#
+# Defaults RUN_ROOT to
+#   $HOME/WormholeLabs/CoreTeam/ClaudeInvestigations/guardian-investigations/harness/runs
+# but can be overridden via env.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS_DIR="$(cd "$HERE/.." && pwd)"
+SCENARIO_DIR="$HARNESS_DIR/scenarios"
+RUN_ROOT="${RUN_ROOT:-$HOME/WormholeLabs/CoreTeam/ClaudeInvestigations/guardian-investigations/harness/runs}"
+
+mkdir -p "$RUN_ROOT"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+BATCH_DIR="$RUN_ROOT/$TS"
+mkdir -p "$BATCH_DIR"
+
+echo "leakharness nightly run @ $TS"
+echo "writing to $BATCH_DIR"
+echo
+
+# Build the binary once for the whole batch.
+BIN="$BATCH_DIR/leakharness"
+(cd "$HARNESS_DIR/../.." && go build -o "$BIN" ./hack/leakharness/cmd/leakharness)
+echo "binary: $BIN"
+echo
+
+# Collect every scenario yaml except the defaults stub.
+mapfile -t SCENARIOS < <(find "$SCENARIO_DIR" -maxdepth 1 -name '*.yaml' \! -name '_*.yaml' | sort)
+
+# Tabular header.
+printf '%-20s %-14s %14s %18s %16s %18s\n' \
+  "scenario" "verdict" "rss_mb_per_h" "heap_inuse_mb_p_h" "goroutines_p_h" "peak_rss_MiB"
+printf '%-20s %-14s %14s %18s %16s %18s\n' \
+  "--------" "-------" "------------" "-----------------" "--------------" "------------"
+
+for scenario in "${SCENARIOS[@]}"; do
+  name="$(basename "$scenario" .yaml)"
+  outdir="$BATCH_DIR/$name"
+  mkdir -p "$outdir"
+  log="$outdir/console.log"
+
+  if ! "$BIN" run --out "$outdir" "$scenario" >"$log" 2>&1; then
+    printf '%-20s %-14s %14s %18s %16s %18s\n' "$name" "ERROR" "-" "-" "-" "-"
+    continue
+  fi
+
+  summary="$outdir/summary.json"
+  if [ ! -f "$summary" ]; then
+    printf '%-20s %-14s %14s %18s %16s %18s\n' "$name" "NO_SUMMARY" "-" "-" "-" "-"
+    continue
+  fi
+
+  verdict="$(jq -r '.verdict' "$summary")"
+  rss_slope="$(jq -r '.slopes.rss_mb_per_hour' "$summary")"
+  heap_slope="$(jq -r '.slopes.heap_inuse_mb_per_hour' "$summary")"
+  gr_slope="$(jq -r '.slopes.goroutines_per_hour' "$summary")"
+  peak_rss="$(jq -r '.peak_rss_bytes / 1024 / 1024 | floor' "$summary")"
+
+  printf '%-20s %-14s %14.2f %18.2f %16.2f %18d\n' \
+    "$name" "$verdict" "$rss_slope" "$heap_slope" "$gr_slope" "$peak_rss"
+done
+
+echo
+echo "done. summaries under $BATCH_DIR"

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -97,6 +97,10 @@ func (c mockEVMConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types
 	panic("unimplemented")
 }
 
+func (c mockEVMConnector) Close() error {
+	return nil
+}
+
 func generateGuardianSigners(num int) (signers []guardiansigner.GuardianSigner, addrs []common.Address) {
 	for i := 0; i < num; i++ {
 		signer, err := guardiansigner.GenerateSignerWithPrivatekeyUnsafe(nil)

--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -203,6 +203,10 @@ func (e *mockConnectorForBatchPoller) SubscribeNewHead(ctx context.Context, ch c
 	return mockSubscription{}, nil
 }
 
+func (e *mockConnectorForBatchPoller) Close() error {
+	return nil
+}
+
 func batchShouldHaveAllThree(t *testing.T, block []*NewBlock, blockNum uint64, expectedHash ethCommon.Hash) {
 	require.Equal(t, 3, len(block))
 	hasFinalized := false

--- a/node/pkg/watchers/evm/connectors/common.go
+++ b/node/pkg/watchers/evm/connectors/common.go
@@ -63,6 +63,11 @@ type Connector interface {
 	RawBatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	Client() *ethClient.Client
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+	// Close releases the underlying JSON-RPC client. Must be called when the
+	// watcher tears down a connector — go-ethereum's *rpc.Client retains a
+	// dispatch goroutine that is reclaimed only by Close(), so omitting this
+	// on supervisor restart leaks one client (and ~3 goroutines) per restart.
+	Close() error
 }
 
 type PollSubscription struct {

--- a/node/pkg/watchers/evm/connectors/ethereum.go
+++ b/node/pkg/watchers/evm/connectors/ethereum.go
@@ -144,3 +144,13 @@ func (e *EthereumBaseConnector) Client() *ethClient.Client {
 func (e *EthereumBaseConnector) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return e.client.SubscribeNewHead(ctx, ch)
 }
+
+// Close releases the JSON-RPC client. Closing the rawClient signals the
+// go-ethereum dispatch/read/write goroutines to exit and frees the WebSocket
+// or HTTP transport. Safe to call multiple times.
+func (e *EthereumBaseConnector) Close() error {
+	if e.rawClient != nil {
+		e.rawClient.Close()
+	}
+	return nil
+}

--- a/node/pkg/watchers/evm/connectors/ethereum_close_test.go
+++ b/node/pkg/watchers/evm/connectors/ethereum_close_test.go
@@ -1,0 +1,115 @@
+package connectors
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap/zaptest"
+)
+
+// fakeEthRPCServer is an in-process JSON-RPC endpoint that accepts WebSocket
+// upgrades and idles. It is the minimum surface area required to exercise
+// EthereumBaseConnector's lifecycle: the constructor only dials, so the
+// server does not need to answer any RPC methods. Idle connections let the
+// go-ethereum rpc.Client spawn its dispatch/read/write goroutines, which is
+// the goroutine cohort whose ownership Close() must reclaim.
+func fakeEthRPCServer(t *testing.T) string {
+	t.Helper()
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Hold the connection open until the peer closes it. We do not need
+		// to answer any methods because the constructor does no RPC calls.
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				_ = conn.Close()
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// goroutineDelta returns the number of goroutines currently running minus
+// the baseline. It runs a GC and a small settle delay so transient goroutines
+// from the previous step have time to exit.
+func goroutineDelta(baseline int) int {
+	runtime.GC()
+	time.Sleep(200 * time.Millisecond)
+	return runtime.NumGoroutine() - baseline
+}
+
+// TestEthereumBaseConnector_CloseReleasesGoroutines asserts the central API
+// contract under test: constructing N connectors and Close()-ing each must
+// not leak goroutines.
+//
+// The leak this guards against was observed on vm-guardian-01 between
+// 2026-05-27 and 2026-05-28 (see .claude/tasks/evm-connector-restart-leak.md).
+// (*evm.Watcher).Run() replaces w.ethConn on every supervisor restart
+// without closing the prior client; the go-ethereum *rpc.Client spawns
+// dispatch/read/write goroutines on Dial that are reclaimed only by Close().
+//
+// On the current code this test fails to compile because (*EthereumBaseConnector)
+// has no Close() method and the Connector interface does not declare one.
+// That compile failure IS the failing test for Phase 0 of the fix plan;
+// Phase 1 adds Close() and this test then passes.
+func TestEthereumBaseConnector_CloseReleasesGoroutines(t *testing.T) {
+	url := fakeEthRPCServer(t)
+	logger := zaptest.NewLogger(t)
+	addr := ethCommon.HexToAddress("0x0000000000000000000000000000000000000000")
+
+	// Warm-up dial: the very first WebSocket upgrade in a test process spins
+	// up TLS/HTTP transport singletons that are not reclaimed by Close().
+	// Doing this before snapshotting the goroutine baseline excludes that
+	// noise from the assertion.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	warmup, err := NewEthereumBaseConnector(ctx, "warmup", url, addr, nil, logger)
+	require.NoError(t, err)
+	require.NoError(t, warmup.Close(), "Close() must succeed on a freshly-dialed connector")
+
+	// IgnoreCurrent snapshots all goroutines that exist at this point —
+	// platform init (rjeczalik/notify CFRunLoop on macOS), httptest serve
+	// loops, and the warm-up's TLS singletons — so the verification at the
+	// end of the test only flags goroutines spawned by the loop below.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	baseline := func() int {
+		runtime.GC()
+		time.Sleep(200 * time.Millisecond)
+		return runtime.NumGoroutine()
+	}()
+
+	const restarts = 25
+	for i := 0; i < restarts; i++ {
+		dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		c, err := NewEthereumBaseConnector(dialCtx, "test", url, addr, nil, logger)
+		dialCancel()
+		require.NoError(t, err, "dial %d", i)
+		require.NoError(t, c.Close(), "close %d", i)
+	}
+
+	delta := goroutineDelta(baseline)
+	// Five is a generous upper bound: go-ethereum's *rpc.Client spawns
+	// roughly three goroutines per dial (dispatch + read + write), so a leak
+	// of even a single un-closed connector across 25 restarts would push the
+	// delta to ≳ 75. Five accommodates GC timing jitter without masking the
+	// regression.
+	require.LessOrEqual(t, delta, 5,
+		"goroutines leaked across %d dial/close cycles (delta=%d); Close() is not reclaiming the rpc.Client dispatcher", restarts, delta)
+}

--- a/node/pkg/watchers/evm/connectors/poller_test.go
+++ b/node/pkg/watchers/evm/connectors/poller_test.go
@@ -70,6 +70,7 @@ func (m *mockConnectorForPoller) GetLatest(ctx context.Context) (latest, finaliz
 	return m.prevLatest, m.prevFinalized, m.prevSafe, nil
 }
 func (m *mockConnectorForPoller) Client() *ethClient.Client { return m.client }
+func (m *mockConnectorForPoller) Close() error              { return nil }
 func (m *mockConnectorForPoller) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return nil, fmt.Errorf("not supported on HTTP")
 }

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -289,6 +289,14 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 		return fmt.Errorf("failed to verify evm chain id: %w", verifyErr)
 	}
 
+	// Reset Run-scoped state. The watcher value persists across supervisor
+	// restarts (see config.go), so any map filled by a prior Run must be
+	// re-initialised here. Without this, pending observations stranded by an
+	// upstream RPC failure accumulate indefinitely.
+	w.pendingMu.Lock()
+	w.pending = make(map[pendingKey]*pendingMessage)
+	w.pendingMu.Unlock()
+
 	// Connect to the node using the appropriate type of connector.
 	{
 		var finalizedPollingSupported, safePollingSupported bool
@@ -300,6 +308,19 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 			return fmt.Errorf(`failed to create connection to url "%s": %w`, w.url, err)
 		}
+
+		// Release the JSON-RPC client when Run returns. The supervisor restarts
+		// Run on error (mezo testnet exhibits this every ~30 min during RPC
+		// flaps); without this defer each restart strands the prior
+		// *rpc.Client plus its dispatch goroutines. Captured by value so the
+		// defer keeps a reference to this particular connector even if a
+		// later branch replaces w.ethConn.
+		ethConnToClose := w.ethConn
+		defer func() {
+			if ethConnToClose != nil {
+				_ = ethConnToClose.Close()
+			}
+		}()
 
 		// Log the connector details for troubleshooting purposes.
 		if finalizedPollingSupported {

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -59,6 +59,7 @@ type (
 		Jsonrpc string               `json:"jsonrpc"`
 		Result  SuiEventResponseData `json:"result"`
 		ID      int                  `json:"id"`
+		Error   *SuiEventError       `json:"error,omitempty"`
 	}
 	SuiEventResponseData struct {
 		Data       []SuiResult `json:"data"`
@@ -421,34 +422,54 @@ func (e *Watcher) Run(ctx context.Context) error {
 	readiness.SetReady(e.readinessSync)
 
 	common.RunWithScissors(ctx, errC, "sui_data_pump", func(ctx context.Context) error {
+		// Backoff bounds the retry rate when getEvents fails (e.g. RPC degraded,
+		// upstream pruning index gaps). Without this, errors trigger a tight retry
+		// loop that floods logs and drives heap allocation toward GOMEMLIMIT.
+		backoff := e.loopDelay
+		const maxBackoff = 30 * time.Second
+
 		for {
 			select {
 			case <-ctx.Done():
-				logger.Error("sui_data_pump context done")
+				logger.Info("sui_data_pump shutting down", zap.Error(ctx.Err()))
 				return ctx.Err()
-
 			default:
-				dataWithEvents, err := e.getEvents(ctx)
-				if err != nil {
-					logger.Error("sui_data_pump Error", zap.Error(err))
-					continue
+			}
+
+			dataWithEvents, err := e.getEvents(ctx)
+			if err != nil {
+				logger.Warn("sui_data_pump getEvents failed",
+					zap.Error(err),
+					zap.Duration("backoff", backoff))
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(backoff):
 				}
-				// dataWithEvents is in descending order, so we need to process it in reverse order.
-				if len(dataWithEvents) > 0 {
-					for idx := len(dataWithEvents) - 1; idx >= 0; idx-- {
-						event := dataWithEvents[idx]
-						err = e.inspectBody(ctx, logger, event.result, false)
-						if err != nil {
-							logger.Error("inspectBody Error", zap.Error(err))
-							continue
-						}
-						if event.checkpoint > e.latestProcessedCheckpoint {
-							e.latestProcessedCheckpoint = event.checkpoint
-						}
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
 					}
 				}
-				time.Sleep(e.loopDelay) //nolint:forbidigo // TODO: This code should be refactored to not use time.Sleep
+				continue
 			}
+			backoff = e.loopDelay
+
+			// dataWithEvents is in descending order, so we need to process it in reverse order.
+			if len(dataWithEvents) > 0 {
+				for idx := len(dataWithEvents) - 1; idx >= 0; idx-- {
+					event := dataWithEvents[idx]
+					if err := e.inspectBody(ctx, logger, event.result, false); err != nil {
+						logger.Error("inspectBody Error", zap.Error(err))
+						continue
+					}
+					if event.checkpoint > e.latestProcessedCheckpoint {
+						e.latestProcessedCheckpoint = event.checkpoint
+					}
+				}
+			}
+			time.Sleep(e.loopDelay) //nolint:forbidigo // TODO: This code should be refactored to not use time.Sleep
 		}
 	})
 
@@ -575,11 +596,16 @@ func (w *Watcher) getEvents(ctx context.Context) ([]SuiResultInfo, error) {
 			results = append(results, datum)
 		}
 		if (len(res.Result.Data) == 0) || (len(txs) == 0) {
-			// In devnet (tilt) the core contract may not have any events and we don't want to flood the logs.
+			// On mainnet and testnet the core bridge has emitted events, so an
+			// empty result here points to upstream RPC pruning and must be
+			// surfaced so operators can rotate the endpoint. The pump loop's
+			// backoff bounds the retry rate. Devnet is exempt because a fresh
+			// local core bridge legitimately has no events until the first
+			// wormhole message is published.
 			if w.unsafeDevMode {
 				return retVal, nil
 			}
-			return retVal, errors.New("getEvents was unable to get any events")
+			return retVal, errors.New("getEvents: suix_queryEvents returned no results, suspect upstream pruning")
 		}
 		// Get and check the checkpoint for the last event against the lastProcessedHeight to see if we are done.
 		height, hErr := w.getCheckpointForDigest(ctx, txs[len(txs)-1])
@@ -712,6 +738,9 @@ func (w *Watcher) suiQueryEvents(ctx context.Context, payload string) (SuiEventR
 	err = json.Unmarshal(body, &retVal)
 	if err != nil {
 		return retVal, fmt.Errorf("suix_queryEvents failed to unmarshal body: %s, error: %w", string(body), err)
+	}
+	if retVal.Error != nil {
+		return retVal, fmt.Errorf("suix_queryEvents RPC error %d: %s", retVal.Error.Code, retVal.Error.Message)
 	}
 	return retVal, nil
 }

--- a/node/pkg/watchers/sui/watcher_integration_test.go
+++ b/node/pkg/watchers/sui/watcher_integration_test.go
@@ -1,0 +1,269 @@
+package sui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/readiness"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/stretchr/testify/require"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap/zaptest"
+)
+
+// mockSuiRPC is a configurable JSON-RPC server stub used to exercise the watcher's HTTP path
+// without a live Sui node. The handler returns a response body keyed by the JSON-RPC method
+// name; callCounts tracks invocations per method so tests can assert hot-loop behavior.
+type mockSuiRPC struct {
+	server     *httptest.Server
+	callCounts map[string]*int64
+}
+
+func init() {
+	// The readiness package uses a process-global registry that panics on double-register.
+	// Multiple integration tests in this file each spin up a Watcher.Run() which calls
+	// readiness.SetReady against the same component key, so we suppress the panic for tests.
+	readiness.NoPanic = true
+}
+
+func newMockSuiRPC(t *testing.T, handler func(method string) string) *mockSuiRPC {
+	t.Helper()
+	m := &mockSuiRPC{callCounts: make(map[string]*int64)}
+	for _, method := range []string{
+		"sui_getLatestCheckpointSequenceNumber",
+		"suix_getLatestSuiSystemState",
+		"suix_queryEvents",
+		"sui_multiGetTransactionBlocks",
+		"sui_getEvents",
+		"sui_getTransactionBlock",
+	} {
+		var c int64
+		m.callCounts[method] = &c
+	}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		raw, _ := io.ReadAll(r.Body)
+		var req struct {
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(raw, &req)
+		if counter, ok := m.callCounts[req.Method]; ok {
+			atomic.AddInt64(counter, 1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(handler(req.Method)))
+	}))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+func (m *mockSuiRPC) calls(method string) int64 {
+	return atomic.LoadInt64(m.callCounts[method])
+}
+
+// newTestWatcher constructs a minimally-configured Watcher pointing at a mock RPC. The
+// production constructor (NewWatcher) is bypassed because it requires SDK lookups and txVerifier
+// wiring that are orthogonal to the data-pump retry behavior under test.
+func newTestWatcher(rpcURL, moveEventType string) *Watcher {
+	return &Watcher{
+		suiRPC:                    rpcURL,
+		suiMoveEventType:          moveEventType,
+		msgChan:                   make(chan *common.MessagePublication, 16),
+		obsvReqC:                  make(chan *gossipv1.ObservationRequest, 1),
+		readinessSync:             common.MustConvertChainIdToReadinessSyncing(vaa.ChainIDSui),
+		latestProcessedCheckpoint: 0,
+		maximumBatchSize:          10,
+		descendingOrder:           true,
+		loopDelay:                 10 * time.Millisecond,
+		queryEventsCmd: fmt.Sprintf(`{"jsonrpc":"2.0", "id": 1, "method": "suix_queryEvents", "params": [{ "MoveEventType": "%s" }, null, %d, %t]}`,
+			moveEventType, 10, true),
+		postTimeout: 5 * time.Second,
+	}
+}
+
+// Test_GetEvents_EmptyResultSurfacesAsError is a regression test for the silent-empty failure
+// mode that drove the 2026-05-25 high-CPU incident on vm-guardian-01. On non-devnet networks
+// the core bridge has emitted events, so an empty result from suix_queryEvents indicates an
+// upstream RPC fault (e.g. pruning, index drift) rather than a benign "no events" state. The
+// fix surfaces this as an error so operators can rotate the endpoint, and the pump loop's
+// backoff bounds the retry rate.
+func Test_GetEvents_EmptyResultSurfacesAsError(t *testing.T) {
+	mock := newMockSuiRPC(t, func(method string) string {
+		if method == "suix_queryEvents" {
+			return `{"jsonrpc":"2.0","id":1,"result":{"data":[],"nextCursor":null,"hasNextPage":false}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	_, err := w.getEvents(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "suspect upstream pruning")
+	require.Equal(t, int64(1), mock.calls("suix_queryEvents"))
+}
+
+// Test_GetEvents_PropagatesUpstreamRPCError exercises the full call chain from getEvents
+// down through suiQueryEvents and into the JSON-RPC error decode added by this commit. With
+// the Error field present on SuiEventResponse, an upstream RPC failure (rate limit, pruned
+// transaction, invalid params, etc.) is no longer silently coerced to an empty result; the
+// code and message reach the caller intact so operators can diagnose the actual failure.
+func Test_GetEvents_PropagatesUpstreamRPCError(t *testing.T) {
+	mock := newMockSuiRPC(t, func(method string) string {
+		if method == "suix_queryEvents" {
+			return `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"transaction events pruned"}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	_, err := w.getEvents(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-32603")
+	require.Contains(t, err.Error(), "transaction events pruned")
+	require.NotContains(t, err.Error(), "suspect upstream pruning",
+		"a JSON-RPC error must not be coerced to the generic empty-result message")
+}
+
+// Test_GetEvents_PartialProgressIsDiscardedOnEmptyPage documents pagination behavior that this
+// commit does not change: when page 1 returns events with HasNextPage=true and page 2 returns
+// an empty result set, getEvents returns the empty-page error and the events collected from
+// page 1 are discarded. The pump loop's backoff now bounds the retry rate, so this no longer
+// produces a hot loop, but the partial-progress loss remains and is worth marking explicitly
+// in case a future change opts to return the accumulated events instead of discarding them.
+func Test_GetEvents_PartialProgressIsDiscardedOnEmptyPage(t *testing.T) {
+	var queryCalls int64
+	mock := newMockSuiRPC(t, func(method string) string {
+		switch method {
+		case "suix_queryEvents":
+			n := atomic.AddInt64(&queryCalls, 1)
+			if n == 1 {
+				return `{"jsonrpc":"2.0","id":1,"result":{"data":[{"id":{"txDigest":"DIGEST1","eventSeq":"0"},"packageId":"0xabc","transactionModule":"publish_message","sender":"0xdead","type":"0xabc::publish_message::WormholeMessage","parsedJson":{},"bcs":"","timestampMs":"0"}],"nextCursor":{"txDigest":"DIGEST1","eventSeq":"0"},"hasNextPage":true}}`
+			}
+			return `{"jsonrpc":"2.0","id":1,"result":{"data":[],"nextCursor":null,"hasNextPage":false}}`
+		case "sui_getTransactionBlock":
+			return `{"jsonrpc":"2.0","id":1,"result":{"digest":"DIGEST1","checkpoint":"99999999"}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	retVal, err := w.getEvents(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "suspect upstream pruning")
+	require.Empty(t, retVal, "events collected on page 1 are discarded when a later page returns empty")
+}
+
+// runWatcherUnderSupervisor drives the watcher's full Run() loop under a real supervisor
+// context for the requested duration. The mock RPC is supplied by the caller. The function
+// blocks until the supervisor goroutine exits, so any post-call reads on the watcher are
+// safely synchronized with writes from inside Run().
+func runWatcherUnderSupervisor(t *testing.T, w *Watcher, runFor time.Duration) {
+	t.Helper()
+	rootCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zaptest.NewLogger(t)
+	done := make(chan struct{})
+
+	go supervisor.New(rootCtx, logger, func(ctx context.Context) error {
+		if err := supervisor.Run(ctx, "sui-test", w.Run); err != nil {
+			return err
+		}
+		supervisor.Signal(ctx, supervisor.SignalHealthy)
+		<-ctx.Done()
+		close(done)
+		return nil
+	}, supervisor.WithPropagatePanic)
+
+	time.Sleep(runFor)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not shut down within 2s of cancel")
+	}
+}
+
+// Test_DataPump_AppliesBackoffOnPersistentError is a regression test for the no-backoff hot
+// loop that drove ~24 getEvents calls/sec against the upstream RPC during the 2026-05-25
+// incident. With the exponential backoff added by this commit (start at loopDelay, double on
+// each consecutive failure, capped at 30s), a 500ms window starting from loopDelay=10ms emits
+// at most ~7 calls: 10ms + 20 + 40 + 80 + 160 + 320 → next attempt is past the window. The
+// pre-fix code emitted thousands of calls in the same window. The 20-call ceiling gives a
+// healthy safety margin against scheduler jitter while still failing loudly on any regression
+// that removes or weakens the backoff.
+func Test_DataPump_AppliesBackoffOnPersistentError(t *testing.T) {
+	mock := newMockSuiRPC(t, func(method string) string {
+		switch method {
+		case "sui_getLatestCheckpointSequenceNumber":
+			return `{"jsonrpc":"2.0","id":1,"result":"12345"}`
+		case "suix_getLatestSuiSystemState":
+			return `{"jsonrpc":"2.0","id":1,"result":{"epoch":"1","protocolVersion":"1"}}`
+		case "suix_queryEvents":
+			return `{"jsonrpc":"2.0","id":1,"result":{"data":[],"nextCursor":null,"hasNextPage":false}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	readiness.RegisterComponent(w.readinessSync)
+
+	runWatcherUnderSupervisor(t, w, 500*time.Millisecond)
+
+	calls := mock.calls("suix_queryEvents")
+	require.LessOrEqual(t, calls, int64(20),
+		"expected ≤20 suix_queryEvents calls in 500ms with exponential backoff; got %d. "+
+			"A regression that removes the backoff would push this into the thousands.",
+		calls)
+	require.GreaterOrEqual(t, calls, int64(1),
+		"the data pump must still issue at least one call; got %d", calls)
+}
+
+// Test_Restart_SetsCheckpointToHead proves that on every (re)start the watcher re-anchors
+// latestProcessedCheckpoint to the current Sui head via sui_getLatestCheckpointSequenceNumber
+// at watcher.go:407-411. This refutes the "stuck walking back to a stale cursor" theory: a
+// fresh process cannot be persistently descending through historical events, because each
+// start sets the floor to whatever the RPC reports as `latest` at that moment. Any persistent
+// post-restart failure must therefore originate from page 1 of suix_queryEvents itself, not
+// from the pagination walk.
+func Test_Restart_SetsCheckpointToHead(t *testing.T) {
+	const headCheckpoint int64 = 42424242
+
+	mock := newMockSuiRPC(t, func(method string) string {
+		switch method {
+		case "sui_getLatestCheckpointSequenceNumber":
+			return fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":"%d"}`, headCheckpoint)
+		case "suix_getLatestSuiSystemState":
+			return `{"jsonrpc":"2.0","id":1,"result":{"epoch":"1","protocolVersion":"1"}}`
+		case "suix_queryEvents":
+			// Force the pump's error branch so latestProcessedCheckpoint cannot be advanced
+			// further by the success path at watcher.go:445-447. Any value observed after
+			// shutdown therefore came from the startup assignment, not from event processing.
+			return `{"jsonrpc":"2.0","id":1,"result":{"data":[],"nextCursor":null,"hasNextPage":false}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	w.latestProcessedCheckpoint = 0
+	readiness.RegisterComponent(w.readinessSync)
+
+	runWatcherUnderSupervisor(t, w, 200*time.Millisecond)
+
+	require.Equal(t, headCheckpoint, w.latestProcessedCheckpoint,
+		"on (re)start the watcher must anchor latestProcessedCheckpoint to the current Sui head")
+}
+

--- a/node/pkg/watchers/sui/watcher_integration_test.go
+++ b/node/pkg/watchers/sui/watcher_integration_test.go
@@ -267,3 +267,83 @@ func Test_Restart_SetsCheckpointToHead(t *testing.T) {
 		"on (re)start the watcher must anchor latestProcessedCheckpoint to the current Sui head")
 }
 
+// Test_GetEvents_PrunedTxOnPageOne_GetCheckpointForDigest probes the hypothesis that page 1
+// of suix_queryEvents can reference a transaction whose body has been pruned from the upstream
+// RPC's transaction store while still appearing in the event index. The watcher calls
+// getCheckpointForDigest (sui_getTransactionBlock) against the oldest tx in each page to
+// decide whether to paginate further; if that tx has been pruned, QuickNode returns a JSON-RPC
+// error -32602 ("Could not find the referenced transaction..."). GetCheckpointResponse has no
+// Error field today (sibling defect to the SuiEventResponse fix), so json.Unmarshal silently
+// drops the error, Result.Checkpoint stays empty, and the watcher reports an opaque
+// ParseInt("") failure instead of the actionable upstream pruning message.
+//
+// This is the alternative failure path the 2026-05-25 incident could have taken — distinct from
+// the "pagination walks into the prune zone" path, since here even page 1 alone is enough.
+func Test_GetEvents_PrunedTxOnPageOne_GetCheckpointForDigest(t *testing.T) {
+	mock := newMockSuiRPC(t, func(method string) string {
+		switch method {
+		case "suix_queryEvents":
+			// Page 1: a single event referencing a tx that exists in the event index but
+			// not in the transaction store. HasNextPage=true so we reach the
+			// getCheckpointForDigest call before any break-condition shortcut fires.
+			return `{"jsonrpc":"2.0","id":1,"result":{"data":[{"id":{"txDigest":"PRUNED_TX_ON_PAGE_ONE","eventSeq":"0"},"packageId":"0xabc","transactionModule":"publish_message","sender":"0xdead","type":"0xabc::publish_message::WormholeMessage","parsedJson":{},"bcs":"","timestampMs":"0"}],"nextCursor":{"txDigest":"PRUNED_TX_ON_PAGE_ONE","eventSeq":"0"},"hasNextPage":true}}`
+		case "sui_getTransactionBlock":
+			// Real shape observed from QuickNode for tx 9XqKQPYvfAk... on 2026-05-26.
+			return `{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Could not find the referenced transaction [TransactionDigest(PRUNED_TX_ON_PAGE_ONE)]."}}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	_, err := w.getEvents(context.Background())
+
+	require.Error(t, err)
+	// Current behavior demonstrates the sibling silent-coercion defect: the upstream
+	// -32602 / "Could not find the referenced transaction" message is lost, and the caller
+	// sees a generic ParseInt failure that gives no hint about the actual cause (upstream
+	// pruning). Once GetCheckpointResponse grows an Error field analogous to
+	// SuiEventResponse.Error, this assertion should flip to check for "-32602" and
+	// "Could not find the referenced transaction" in the surfaced error.
+	require.Contains(t, err.Error(), "getCheckpointForDigest failed to ParseInt",
+		"sibling defect: GetCheckpointResponse silently coerces JSON-RPC errors to ParseInt failure")
+}
+
+// Test_GetEvents_PrunedTxInBatch_MultiGetTransactionBlocks documents the analogous defect on the
+// batched checkpoint lookup. When the watcher gets past the per-tx checkpoint check and calls
+// getMultipleBlocks (sui_multiGetTransactionBlocks), QuickNode returns one entry per requested
+// digest, but pruned entries are degraded to digest-only (no `checkpoint` field). The watcher
+// then ParseInt("")s on the missing field at watcher.go:606. MultipleBlockResult / TxBlockResult
+// also have no Error field, so a JSON-RPC error from this method would similarly be coerced to
+// an empty-shape response and produce the same ParseInt failure.
+//
+// Observed shape from QuickNode on 2026-05-26:
+//
+//	sui_multiGetTransactionBlocks(["9XqKQPYvfAk..."])
+//	→ {"result": [{"digest": "9XqKQPYvfAk..."}]}   ← no checkpoint field
+func Test_GetEvents_PrunedTxInBatch_MultiGetTransactionBlocks(t *testing.T) {
+	mock := newMockSuiRPC(t, func(method string) string {
+		switch method {
+		case "suix_queryEvents":
+			// Page 1 with one event; HasNextPage=false so we break out of pagination and
+			// reach the getMultipleBlocks call directly.
+			return `{"jsonrpc":"2.0","id":1,"result":{"data":[{"id":{"txDigest":"PRUNED_BATCH_TX","eventSeq":"0"},"packageId":"0xabc","transactionModule":"publish_message","sender":"0xdead","type":"0xabc::publish_message::WormholeMessage","parsedJson":{},"bcs":"","timestampMs":"0"}],"nextCursor":null,"hasNextPage":false}}`
+		case "sui_getTransactionBlock":
+			// Allow the per-tx checkpoint lookup to succeed so we reach getMultipleBlocks
+			// with a tx the watcher believes is fresh.
+			return `{"jsonrpc":"2.0","id":1,"result":{"digest":"PRUNED_BATCH_TX","checkpoint":"99999999"}}`
+		case "sui_multiGetTransactionBlocks":
+			// Real shape observed from QuickNode: one entry per digest, but pruned txs
+			// come back with only the digest field populated — no checkpoint.
+			return `{"jsonrpc":"2.0","id":1,"result":[{"digest":"PRUNED_BATCH_TX"}]}`
+		}
+		return `{"jsonrpc":"2.0","id":1,"result":null}`
+	})
+
+	w := newTestWatcher(mock.server.URL, "0xabc::publish_message::WormholeMessage")
+	_, err := w.getEvents(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "getEvents failed to ParseInt",
+		"missing checkpoint field on a batched response is surfaced as opaque ParseInt failure")
+}
+

--- a/node/pkg/watchers/sui/watcher_test.go
+++ b/node/pkg/watchers/sui/watcher_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -293,4 +295,43 @@ func TestVerifyAndPublish_Samples(t *testing.T) {
 		})
 
 	}
+}
+
+// Test_SuiEventResponse_DecodesRPCError ensures that a JSON-RPC error response
+// (as returned by upstream Sui RPC servers when, e.g., a referenced transaction
+// has been pruned) populates the Error field. Without the Error field on
+// SuiEventResponse, the response decodes to an empty Result and is
+// indistinguishable from a legitimate empty page, which masks real upstream
+// failures behind a generic "no events" log message.
+func Test_SuiEventResponse_DecodesRPCError(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Could not find the referenced transaction events [TransactionDigest(9XqKQPYvfAkEWSxrYX4tyTuD6BhG6togMxeHjNKDAdTD)]."}}`)
+
+	var resp SuiEventResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	require.NotNil(t, resp.Error, "Error field should be populated from JSON-RPC error response")
+	require.Equal(t, int64(-32603), resp.Error.Code)
+	require.Contains(t, resp.Error.Message, "9XqKQPYvfAkEWSxrYX4tyTuD6BhG6togMxeHjNKDAdTD")
+	require.Empty(t, resp.Result.Data, "Result.Data should be empty when an error is returned")
+}
+
+// Test_suiQueryEvents_PropagatesRPCError ensures that when the upstream Sui RPC
+// returns a JSON-RPC error, suiQueryEvents surfaces that error to its caller
+// rather than swallowing it and returning a SuiEventResponse with empty data.
+func Test_suiQueryEvents_PropagatesRPCError(t *testing.T) {
+	rpcBody := `{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Could not find the referenced transaction events [TransactionDigest(abc)]."}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(rpcBody))
+	}))
+	defer srv.Close()
+
+	w := &Watcher{
+		suiRPC:      srv.URL,
+		postTimeout: 5 * time.Second,
+	}
+
+	_, err := w.suiQueryEvents(context.Background(), `{"jsonrpc":"2.0","id":1,"method":"suix_queryEvents","params":[]}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-32603")
+	require.Contains(t, err.Error(), "Could not find the referenced transaction events")
 }


### PR DESCRIPTION
## Summary

Hardens guardian chain-watchers against a class of memory/goroutine leaks and adds in-process tooling to detect them. The PR contains two concrete leak fixes — the EVM watcher connector lifecycle and the Sui data-pump retry loop — alongside a leak-detection harness and pprof integration that make this leak class observable and regression-tested going forward.

## Background

Two distinct leaks motivated this work:

- **EVM watcher** — on `vm-guardian-01` (2026-05-27 → 2026-05-28), RSS grew ~160 MB/h (535 MB → 1499 MB) while goroutine count rose 859 → 944. The prior `Connector` was never closed across supervisor restarts, so its dispatcher goroutines and stale pending entries accumulated. The mezo testnet endpoint was the trigger in production, but any flaky EVM RPC reproduces it.
- **Sui watcher (CORE-2815, 2026-05-26)** — the `sui_data_pump` retried `getEvents` in a tight loop on failure, flooding logs and driving heap allocation toward `GOMEMLIMIT`.

## Changes

- **`fix(node): close EVM watcher connector on supervisor restart`** — adds `Close()` to the `Connector` interface and `EthereumBaseConnector`. `Run()` now defers `Close()` and re-initialises the pending observation map, so dispatcher goroutines and stale entries do not survive supervisor restarts.
- **`fix(node): bound sui watcher retry loop and surface RPC errors (CORE-2815)`** — adds exponential backoff (capped at 30s) to the data pump, propagates JSON-RPC errors, and surfaces empty-result responses (suspected upstream pruning) on mainnet/testnet.
- **`feat(node): guardian leak detection harness`** — Go-native harness under `node/hack/leakharness/` that exercises watcher connector lifecycles against controllable fake RPC servers and reports memory/goroutine/FD slope per scenario. Also bumps `rjeczalik/notify` v0.9.1 → v0.9.3 to drop the deprecated macOS FSEvents API.
- **`feat(node): add pprof profiling to leak harness`** — each run writes heap/goroutine pprof bundles and exposes a loopback-only live pprof server for alloc-site localisation.
- Test commits covering the Sui backoff/RPC-error paths and checkpoint coercion defects.

## Testing

- `go test ./pkg/watchers/evm/connectors/...` — pass (includes `TestEthereumBaseConnector_CloseReleasesGoroutines`, goleak-backed)
- `go test ./pkg/watchers/sui/...` — pass
- `go test ./hack/leakharness/...` — pass (incl. compressed E2E scenarios)

## Notes

- Base branch is `tron-node` deliberately; this is the integration target.
- The XRPL watcher work and unrelated chores present on the original working branch are excluded — they ship via their own branches.
