### PR TITLE
canton: make core-bridge contracts publicly readable via a public observer

### DIFF
--- a/canton/README.md
+++ b/canton/README.md
@@ -383,23 +383,21 @@ approval, and is not public-observed.)
 
 `public` is an **ordinary party with no choices and no authority**; observing it
 only widens visibility. It is chosen once at `setup` and stored on `CoreState` —
-the **single source of truth**. `ApproveEmitter` sources it *authoritatively from
-`CoreState`* (fetching the operator's own singleton), not from a requester-supplied
+the **single source of truth**. `ApproveEmitter` sources it _authoritatively from
+`CoreState`_ (fetching the operator's own singleton), not from a requester-supplied
 value, so every `Emitter`/`EmitterIdentity` is guaranteed to share the one
 canonical `public` party; it is then carried forward unchanged on every recreate
 (publish, governance transition). This makes "public observability is always
 granted to the canonical party" an enforced on-ledger invariant, not a convention.
 
 **The Daml change is necessary but not sufficient.** Listing `public` as an
-observer makes the contracts *visible to that party*; letting arbitrary readers
+observer makes the contracts _visible to that party_; letting arbitrary readers
 actually **read as** `public` is a Canton topology/participant concern — grant
 read-as rights for the `public` party on each participant that should serve
 reads, or stand up a read-only front-end (the JSON Ledger API or a Participant
 Query Store instance) configured to read as `public`, so consumers query an
-endpoint and never need the party id. A party id is `hint::fingerprint`, where
-the fingerprint is a hash of the allocating namespace's key — deployment-specific
-and not guessable — so the `public` party id must be published or fronted by an
-API; it cannot be inferred.
+endpoint and never need the party id. A party id has format`hint::fingerprint` so it
+will need to be published.
 
 ---
 

--- a/canton/README.md
+++ b/canton/README.md
@@ -152,6 +152,7 @@ Daml package name: `wormhole-core` (the `core` package). Module layout under
 template CoreState
   with
     operator           : Party          -- holds/advances the singleton; the "deployer"
+    public             : Party          -- read-only visibility party (§4.6)
     chainId            : Int            -- 72
     governanceChainId  : Int            -- 1 (Solana)
     governanceContract : Bytes32        -- 0x..0004 (the governance emitter)
@@ -217,19 +218,21 @@ template EmitterRequest with
 template EmitterIdentity with
     operator : Party
     owner    : Party
+    public   : Party                       -- read-only visibility party (§4.6)
   where
     signatory operator
-    observer owner
+    observer owner, public
 
 template Emitter
   with
     operator : Party
     owner    : Party
+    public   : Party                       -- read-only visibility party (§4.6)
     identity : ContractId EmitterIdentity  -- permanent; address = keccak256(this cid)
     sequence : Int                         -- next sequence to assign (per-emitter)
   where
     signatory operator
-    observer owner
+    observer owner, public
     -- No contract key (Canton 3.x); owner tracks the current cid off-ledger.
 ```
 
@@ -367,6 +370,36 @@ Matches EVM (`Setters.sol`): when a new set is installed, the previous set's
 `expirationTime` is set to `effectiveTime + 86400` (1 day). `verifyVAA` accepts a
 non-current set only while `effectiveTime < expirationTime`. The current set
 never expires.
+
+### 4.6 Public readability
+
+Canton contracts are private to their stakeholders (signatories + observers), so
+by default only the `operator` and an emitter's `owner` could read the bridge
+state. To make the full record world-readable — config, emitter registrations,
+per-emitter sequences, and every published message — the durable templates
+`CoreState`, `EmitterIdentity`, and `Emitter` carry a `public` party and list it
+as an `observer`. (`EmitterRequest` is a transient proposal, archived on
+approval, and is not public-observed.)
+
+`public` is an **ordinary party with no choices and no authority**; observing it
+only widens visibility. It is chosen once at `setup` and stored on `CoreState` —
+the **single source of truth**. `ApproveEmitter` sources it *authoritatively from
+`CoreState`* (fetching the operator's own singleton), not from a requester-supplied
+value, so every `Emitter`/`EmitterIdentity` is guaranteed to share the one
+canonical `public` party; it is then carried forward unchanged on every recreate
+(publish, governance transition). This makes "public observability is always
+granted to the canonical party" an enforced on-ledger invariant, not a convention.
+
+**The Daml change is necessary but not sufficient.** Listing `public` as an
+observer makes the contracts *visible to that party*; letting arbitrary readers
+actually **read as** `public` is a Canton topology/participant concern — grant
+read-as rights for the `public` party on each participant that should serve
+reads, or stand up a read-only front-end (the JSON Ledger API or a Participant
+Query Store instance) configured to read as `public`, so consumers query an
+endpoint and never need the party id. A party id is `hint::fingerprint`, where
+the fingerprint is a hash of the allocating namespace's key — deployment-specific
+and not guessable — so the `public` party id must be published or fronted by an
+API; it cannot be inferred.
 
 ---
 

--- a/canton/core/daml/Wormhole/Core/Setup.daml
+++ b/canton/core/daml/Wormhole/Core/Setup.daml
@@ -25,13 +25,15 @@ defaultGovernanceContract = "000000000000000000000000000000000000000000000000000
 -- the supplied governance configuration. The caller @create@s it as @operator@.
 mkInitialCoreState :
   Party        -- ^ operator
+  -> Party     -- ^ public (read-only visibility party)
   -> Int       -- ^ governance chain id
   -> Bytes32   -- ^ governance contract
   -> [Bytes20] -- ^ initial guardian addresses (set 0)
   -> CoreState
-mkInitialCoreState operator govChain govContract initialGuardians =
+mkInitialCoreState operator public govChain govContract initialGuardians =
   CoreState with
     operator
+    public
     chainId = cantonChainId
     governanceChainId = govChain
     governanceContract = normalizeHex govContract

--- a/canton/core/daml/Wormhole/Core/State.daml
+++ b/canton/core/daml/Wormhole/Core/State.daml
@@ -22,6 +22,19 @@
 -- sequence without the operator's authority, matching EVM where anyone may call
 -- @publishMessage@. 'CoreState' holds only the shared config and governance
 -- state.
+--
+-- PUBLIC READABILITY: the durable templates ('CoreState', 'EmitterIdentity',
+-- 'Emitter') carry a @public@ party and list it as an 'observer', so the full
+-- record (config, emitter registrations, sequences, and published messages) is
+-- readable by anyone the participant grants read-as rights to that party.
+-- @public@ is an ordinary party with no choices and no authority — it only widens
+-- visibility. Granting arbitrary readers the right to read as @public@ is a
+-- Canton topology/participant concern, not enforced here; see canton/README.md.
+-- The @public@ party is chosen once at setup and stored on 'CoreState'; it is the
+-- SINGLE SOURCE OF TRUTH. 'ApproveEmitter' sources it from 'CoreState' (not from a
+-- requester-supplied value) so every 'Emitter'/'EmitterIdentity' is guaranteed to
+-- share the one canonical @public@ party, and it is carried forward on every
+-- recreate (publish, governance transition).
 module Wormhole.Core.State where
 
 import DA.Map (Map)
@@ -70,6 +83,7 @@ maxPayloadBytes = 750
 template CoreState
   with
     operator           : Party              -- owns/advances the singleton; no power over outcomes
+    public             : Party              -- read-only visibility party; see module header
     chainId            : Int                -- 72 (Canton)
     governanceChainId  : Int                -- 1 (Solana)
     governanceContract : Bytes32            -- governance emitter address
@@ -79,6 +93,9 @@ template CoreState
     consumedGovernance : Set Bytes32        -- replay protection, keyed by digest
   where
     signatory operator
+    -- @public@ is an ordinary party that the participant grants broad read-as
+    -- rights to; observing it makes the full record publicly readable.
+    observer public
     -- No contract key: Canton 3.x has no unique keys (see module header).
     -- Uniqueness is operator-enforced; the current cid is tracked off-ledger.
 
@@ -174,6 +191,11 @@ currentSetForUpgrade st =
 -- minting an immutable 'EmitterIdentity' and the publishing 'Emitter' bound to
 -- it, in a single transaction.
 --
+-- The @public@ visibility party is NOT chosen here — 'ApproveEmitter' sources it
+-- authoritatively from the operator's 'CoreState', so the durable emitter records
+-- are guaranteed to be observed by the one canonical @public@ party. The request
+-- itself is transient (archived on approval) and is not public-observed.
+--
 -- No address is assigned here: the 32-byte Wormhole emitter address is
 -- @keccak256(<EmitterIdentity contract-id>)@, derived by the guardian watcher (a
 -- 'ContractId' is opaque on-ledger, so it cannot be hashed in Daml). Because
@@ -191,14 +213,27 @@ template EmitterRequest
     observer operator
 
     choice ApproveEmitter : ContractId Emitter
+      with
+        coreStateCid : ContractId CoreState
+          -- ^ The operator's current 'CoreState'; its @public@ party is the single
+          -- source of truth for emitter visibility.
       controller operator
       do
+        -- Source the visibility party AUTHORITATIVELY from CoreState rather than
+        -- trusting a requester-supplied value, so every emitter is guaranteed to
+        -- be observed by the one canonical @public@ party. Assert the CoreState is
+        -- the operator's own (it is the signatory) to reject a foreign CoreState
+        -- carrying a different @public@.
+        cs <- fetch coreStateCid
+        assertMsg "ApproveEmitter: CoreState is not the operator's" (cs.operator == operator)
+        let public = cs.public
         -- The identity cid is known within this transaction; the 'Emitter' stores
         -- it (not a derived address) and the watcher hashes it off-ledger.
-        identityCid <- create EmitterIdentity with operator, owner = requester
+        identityCid <- create EmitterIdentity with operator, owner = requester, public
         create Emitter with
           operator
           owner = requester
+          public
           identity = identityCid
           sequence = 0
 
@@ -214,9 +249,10 @@ template EmitterIdentity
   with
     operator : Party
     owner    : Party
+    public   : Party   -- read-only visibility party; see module header
   where
     signatory operator
-    observer owner
+    observer owner, public
     -- No choices: immutability is the point. Re-minting an 'Emitter' from a fresh
     -- identity would reset the sequence to 0, so identities are strictly one-shot.
 
@@ -228,11 +264,15 @@ template Emitter
   with
     operator  : Party
     owner     : Party
-    identity  : ContractId EmitterIdentity  -- permanent identity; address = keccak256(this cid)
-    sequence  : Int      -- next sequence to assign
+    public    : Party                        -- read-only visibility party; see module header
+    identity  : ContractId EmitterIdentity   -- permanent identity; address = keccak256(this cid)
+    sequence  : Int                          -- next sequence to assign
   where
     signatory operator
-    observer owner
+    -- @owner@ controls publishing; @public@ makes the record (and every
+    -- published message) world-readable. @create this@ on each publish carries
+    -- @public@ forward unchanged.
+    observer owner, public
     -- No contract key (Canton 3.x); the owner tracks the current cid off-ledger.
 
     -- | Publish a Wormhole message. The choice result is the 'WormholeMessage'

--- a/canton/core/daml/Wormhole/Core/State.daml
+++ b/canton/core/daml/Wormhole/Core/State.daml
@@ -191,10 +191,8 @@ currentSetForUpgrade st =
 -- minting an immutable 'EmitterIdentity' and the publishing 'Emitter' bound to
 -- it, in a single transaction.
 --
--- The @public@ visibility party is NOT chosen here — 'ApproveEmitter' sources it
--- authoritatively from the operator's 'CoreState', so the durable emitter records
--- are guaranteed to be observed by the one canonical @public@ party. The request
--- itself is transient (archived on approval) and is not public-observed.
+-- @public@ is sourced from the operator's 'CoreState' on approval, guaranteeing
+-- all emitter records share one canonical visibility party. This request is transient.
 --
 -- No address is assigned here: the 32-byte Wormhole emitter address is
 -- @keccak256(<EmitterIdentity contract-id>)@, derived by the guardian watcher (a
@@ -219,11 +217,8 @@ template EmitterRequest
           -- source of truth for emitter visibility.
       controller operator
       do
-        -- Source the visibility party AUTHORITATIVELY from CoreState rather than
-        -- trusting a requester-supplied value, so every emitter is guaranteed to
-        -- be observed by the one canonical @public@ party. Assert the CoreState is
-        -- the operator's own (it is the signatory) to reject a foreign CoreState
-        -- carrying a different @public@.
+        -- @public@ is fetched from CoreState (operator is signatory) so all emitters
+        -- share the canonical visibility party.
         cs <- fetch coreStateCid
         assertMsg "ApproveEmitter: CoreState is not the operator's" (cs.operator == operator)
         let public = cs.public

--- a/canton/devnet/bootstrap.sh
+++ b/canton/devnet/bootstrap.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # Bootstrap the Wormhole core bridge on the Canton sandbox: allocate the Operator
-# party and create the CoreState (with the devnet guardian) by running the
-# Test.TestCore:setup Daml Script.
+# and Public parties and create the CoreState (with the devnet guardian) by
+# running the Test.TestCore:setup Daml Script.
 #
 # The guardian does NOT need the Operator party id — the watcher uses a wildcard
 # "any party" filter (see canton/README.md §7.1). The party is surfaced below for
@@ -35,11 +35,18 @@ dpm script \
   --ledger-port "${PORT}" \
   --output-file "${RESULT}"
 
-# The setup script returns a tuple {"_1": <Party>, "_2": <ContractId>} as JSON.
-# The party id is the quoted value containing "::" (the namespace separator); the
-# contract id has none. Informational only (the watcher needs no party id).
-OPERATOR_PARTY="$(grep -oE '"[^"]*::[^"]*"' "${RESULT}" | head -1 | tr -d '"')"
+# The setup script returns a tuple {"_1": <Operator>, "_2": <Public>, "_3":
+# <ContractId>} as JSON. Party ids are the quoted values containing "::" (the
+# namespace separator) in tuple order — operator first, then public; the contract
+# id has none. The Operator party is informational (the watcher uses a wildcard
+# filter). The Public party is the read-only visibility party every contract
+# observes (canton/README.md §4.6); surface it so operators can grant read-as
+# rights or point a JSON Ledger API / PQS reader at it.
+PARTIES="$(grep -oE '"[^"]*::[^"]*"' "${RESULT}" | tr -d '"')"
+OPERATOR_PARTY="$(echo "${PARTIES}" | sed -n '1p')"
+PUBLIC_PARTY="$(echo "${PARTIES}" | sed -n '2p')"
 echo "[canton] setup complete; Operator party: ${OPERATOR_PARTY}"
+echo "[canton] public (read-only) party: ${PUBLIC_PARTY}"
 
 touch /canton/success
 echo "[canton] bootstrap done; sleeping"

--- a/canton/test/daml/Test/TestCore.daml
+++ b/canton/test/daml/Test/TestCore.daml
@@ -29,20 +29,23 @@ devnetGuardianPubKey = "04d4a4629979f0c9fa0f0bb54edf33f87c8c5a1f42c0350a30d68f7e
 govSetFeeVAA : Bytes
 govSetFeeVAA = "01000000000100710ab5dcf6885f62016990540e090400f26f41286382dab479a78ed5f85017ff4a562a46379753e94abba1e69b9fec5d1994ac7d9fb145820727df0759bf4f80016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010000000000000000000000000000000000000000000000000000000000436f726503004800000000000000000000000000000000000000000000000000000000000003e8"
 
--- | Bootstrap a devnet 'CoreState' as a fresh operator party.
-setup : Script (Party, ContractId CoreState)
+-- | Bootstrap a devnet 'CoreState' as a fresh operator party, allocating the
+-- read-only @public@ visibility party that every template observes.
+setup : Script (Party, Party, ContractId CoreState)
 setup = do
   operator <- allocateParty "Operator"
+  public <- allocateParty "Public"
   csId <- submit operator do
-    createCmd (mkInitialCoreState operator solanaGovernanceChainId defaultGovernanceContract [devnetGuardian])
-  pure (operator, csId)
+    createCmd (mkInitialCoreState operator public solanaGovernanceChainId defaultGovernanceContract [devnetGuardian])
+  pure (operator, public, csId)
 
 -- | Register an emitter for @owner@: mints its immutable 'EmitterIdentity' and
--- the 'Emitter' bound to it, and returns the 'Emitter' cid.
-registerEmitter : Party -> Party -> Script (ContractId Emitter)
-registerEmitter operator owner = do
+-- the 'Emitter' bound to it. Approval sources the @public@ visibility party
+-- authoritatively from the operator's 'CoreState'. Returns the 'Emitter' cid.
+registerEmitter : Party -> ContractId CoreState -> Party -> Script (ContractId Emitter)
+registerEmitter operator coreStateCid owner = do
   reqId <- submit owner do createCmd EmitterRequest with requester = owner, operator
-  submit operator do exerciseCmd reqId ApproveEmitter
+  submit operator do exerciseCmd reqId ApproveEmitter with coreStateCid
 
 -- | Publishing increments the per-emitter sequence and yields the expected
 -- 'WormholeMessage'. The message carries the emitter's immutable identity (the
@@ -50,9 +53,9 @@ registerEmitter operator owner = do
 -- address itself is not stored on-ledger, so there is nothing to assert here.
 testPublishMessage : Script ()
 testPublishMessage = do
-  (operator, _) <- setup
+  (operator, _, csId) <- setup
   alice <- allocateParty "Alice"
-  emitterId <- registerEmitter operator alice
+  emitterId <- registerEmitter operator csId alice
   Some em <- queryContractId alice emitterId
 
   msg0 <- submit alice do
@@ -73,12 +76,84 @@ testPublishMessage = do
   msg1.identity === em.identity
   pure ()
 
+-- | The @public@ party observes the durable templates, so it can read the full
+-- record of the 'CoreState', each 'Emitter' (including the advanced sequence), and
+-- the 'EmitterIdentity'. Publishing recreates the 'Emitter', and the canonical
+-- @public@ is preserved across every recreation. A party that is neither a
+-- stakeholder nor @public@ sees nothing.
+testPublicVisibility : Script ()
+testPublicVisibility = do
+  (operator, public, csId) <- setup
+  carol <- allocateParty "Carol"
+  emitterId <- registerEmitter operator csId carol
+
+  -- Publish twice, so the Emitter is recreated twice (sequence 0 -> 2).
+  _ <- submit carol do
+    exerciseCmd emitterId PublishMessage with nonce = 1, payload = "abcd", consistencyLevel = 0
+  [(emitterId2, _)] <- query @Emitter carol
+  _ <- submit carol do
+    exerciseCmd emitterId2 PublishMessage with nonce = 2, payload = "beef", consistencyLevel = 0
+
+  -- public reads the shared config singleton...
+  [(csId', cs)] <- query @CoreState public
+  csId' === csId
+  -- ...the twice-recreated emitter with its advanced sequence, still observed by
+  -- the canonical public party sourced from CoreState...
+  [(_, em)] <- query @Emitter public
+  em.sequence === 2
+  em.public === public
+  em.public === cs.public
+  -- ...and the emitter's immutable identity, also observed by public.
+  [(identId, ident)] <- query @EmitterIdentity public
+  em.identity === identId
+  ident.public === public
+
+  -- privacy still holds for a party that is neither stakeholder nor public.
+  outsider <- allocateParty "Outsider"
+  emsForOutsider <- query @Emitter outsider
+  length emsForOutsider === 0
+  csForOutsider <- query @CoreState outsider
+  length csForOutsider === 0
+  identsForOutsider <- query @EmitterIdentity outsider
+  length identsForOutsider === 0
+  pure ()
+
+-- | A governance transition archives and recreates 'CoreState'; the canonical
+-- @public@ party is carried forward, so the new 'CoreState' remains readable by
+-- public.
+testGovernancePreservesPublic : Script ()
+testGovernancePreservesPublic = do
+  (operator, public, csId) <- setup
+  newCsId <- submit operator do
+    exerciseCmd csId SubmitGovernanceVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+  -- public still reads the recreated CoreState, and its public party is unchanged.
+  [(csId', cs)] <- query @CoreState public
+  csId' === newCsId
+  cs.public === public
+  cs.messageFee === 1000
+  pure ()
+
+-- | 'ApproveEmitter' sources @public@ from the operator's own 'CoreState'; a
+-- foreign 'CoreState' (a different operator's) cannot be used to approve.
+testApproveEmitterRejectsForeignCoreState : Script ()
+testApproveEmitterRejectsForeignCoreState = do
+  (operator, _, _) <- setup
+  -- A second, unrelated operator + CoreState (fresh operator party).
+  (_, _, foreignCsId) <- setup
+  dave <- allocateParty "Dave"
+  reqId <- submit dave do createCmd EmitterRequest with requester = dave, operator
+  -- Approving with the foreign CoreState must fail (operator mismatch / not visible).
+  submitMustFail operator do exerciseCmd reqId ApproveEmitter with coreStateCid = foreignCsId
+  pure ()
+
 -- | Payloads larger than 750 bytes are rejected.
 testPayloadTooLarge : Script ()
 testPayloadTooLarge = do
-  (operator, _) <- setup
+  (operator, _, csId) <- setup
   bob <- allocateParty "Bob"
-  emitterId <- registerEmitter operator bob
+  emitterId <- registerEmitter operator csId bob
   -- 751 bytes = 1502 hex chars.
   let bigPayload = mconcat (replicate 1502 "f")
   submitMustFail bob do
@@ -97,7 +172,7 @@ testQuorum = do
 -- | The current guardian set is installed at index 0 and never expires.
 testInitialGuardianSet : Script ()
 testInitialGuardianSet = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   Some cs <- queryContractId operator csId
   cs.guardianSetIndex === 0
   let gs = fromSome (Map.lookup 0 cs.guardianSets)
@@ -109,7 +184,7 @@ testInitialGuardianSet = do
 -- exercises the full keccak256 + DER + secp256k1WithEcdsaOnly path.
 testParseAndVerifyVAA : Script ()
 testParseAndVerifyVAA = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   vaa <- submit operator do
     exerciseCmd csId ParseAndVerifyVAA with
       encodedVAA = govSetFeeVAA
@@ -121,7 +196,7 @@ testParseAndVerifyVAA = do
 -- | A SetMessageFee governance VAA verifies and updates the message fee.
 testGovernanceSetMessageFee : Script ()
 testGovernanceSetMessageFee = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   newCsId <- submit operator do
     exerciseCmd csId SubmitGovernanceVAA with
       encodedVAA = govSetFeeVAA
@@ -137,26 +212,41 @@ testGovernanceSetMessageFee = do
 -- contract-id, which the Go test recomputes to check the mapping.
 integrationPublish : Script Party
 integrationPublish = do
-  (operator, _) <- setup
+  (operator, _, csId) <- setup
   owner <- allocateParty "IntegrationEmitter"
-  emitterId <- registerEmitter operator owner
+  emitterId <- registerEmitter operator csId owner
   _ <- submit owner do
     exerciseCmd emitterId PublishMessage with nonce = 42, payload = "11223344", consistencyLevel = 0
   pure operator
 
+-- | Integration entrypoint for the public-read test: set up the bridge, register
+-- an emitter, and publish once — then return the PUBLIC party so the Go test can
+-- read the active-contract set AS that party and confirm public observability
+-- works over the real Ledger API (not just in-memory Daml Script).
+integrationPublicParty : Script Party
+integrationPublicParty = do
+  (operator, public, csId) <- setup
+  owner <- allocateParty "PublicReadEmitter"
+  emitterId <- registerEmitter operator csId owner
+  _ <- submit owner do
+    exerciseCmd emitterId PublishMessage with nonce = 7, payload = "abcdef", consistencyLevel = 0
+  pure public
+
 -- | Exercise the auto-generated Archive choice on each template (for coverage).
 testArchives : Script ()
 testArchives = do
-  (operator, csId) <- setup
-  submit operator do archiveCmd csId            -- Archive CoreState
-  alice <- allocateParty "ArchAlice"
-  reqId <- submit alice do createCmd EmitterRequest with requester = alice, operator
-  submit alice do archiveCmd reqId              -- Archive EmitterRequest
+  (operator, _, csId) <- setup
+  -- Register an emitter (which needs a live CoreState) BEFORE archiving CoreState.
   bob <- allocateParty "ArchBob"
-  emId <- registerEmitter operator bob
+  emId <- registerEmitter operator csId bob
   submit operator do archiveCmd emId            -- Archive Emitter
   -- The immutable identity is normally never archived; exercise it here for
   -- coverage (operator is its signatory).
   [(identId, _)] <- query @EmitterIdentity operator
   submit operator do archiveCmd identId         -- Archive EmitterIdentity
+  -- A standalone EmitterRequest, to exercise its Archive choice.
+  alice <- allocateParty "ArchAlice"
+  reqId <- submit alice do createCmd EmitterRequest with requester = alice, operator
+  submit alice do archiveCmd reqId              -- Archive EmitterRequest
+  submit operator do archiveCmd csId            -- Archive CoreState (last)
   pure ()

--- a/node/pkg/cantonclient/cantonclient.go
+++ b/node/pkg/cantonclient/cantonclient.go
@@ -132,8 +132,21 @@ type CantonClient interface {
 	// UpdateService.GetUpdateByOffset / GetTransactionByOffset.
 	GetUpdateByOffset(ctx context.Context, offset int64, tmpl TemplateID, choiceName string) (CantonTransaction, error)
 
+	// GetActiveContracts returns the active contracts visible to the client's
+	// read-as party (the ACS snapshot at the current ledger end). Used to read
+	// on-ledger state directly — e.g. to confirm a "public" party can read the
+	// core-bridge contracts it observes. Maps to StateService.GetActiveContracts.
+	GetActiveContracts(ctx context.Context) ([]ActiveContract, error)
+
 	// Close releases the underlying gRPC connection.
 	Close() error
+}
+
+// ActiveContract is a minimal view of a created contract from the ACS: the
+// template it instantiates and its contract id.
+type ActiveContract struct {
+	TemplateID TemplateID
+	ContractID string
 }
 
 // offsetTxIDLen is the fixed width of a Canton TxID (a 32-byte, left-padded,

--- a/node/pkg/cantonclient/cantongrpc.go
+++ b/node/pkg/cantonclient/cantongrpc.go
@@ -73,13 +73,11 @@ func (c *grpcClient) GetLedgerEnd(ctx context.Context) (int64, error) {
 	return resp.GetOffset(), nil
 }
 
-// updateFormat builds the v2 UpdateFormat that selects transactions in
-// LEDGER_EFFECTS shape (so ExercisedEvents — which carry choice results — are
-// included). A wildcard template filter matches every template; the watcher
-// narrows to the core-bridge template/choice in Go. When readAsParty is empty
-// the events of every party hosted on the participant are streamed
-// (filters_for_any_party); otherwise the stream is narrowed to that one party.
-func (c *grpcClient) updateFormat() *apiv2.UpdateFormat {
+// eventFormat builds the v2 EventFormat with a wildcard template filter (matches
+// every template; callers narrow in Go). When readAsParty is empty the events of
+// every party hosted on the participant are included (filters_for_any_party);
+// otherwise the view is narrowed to that one party.
+func (c *grpcClient) eventFormat() *apiv2.EventFormat {
 	wildcard := &apiv2.Filters{
 		Cumulative: []*apiv2.CumulativeFilter{{
 			IdentifierFilter: &apiv2.CumulativeFilter_WildcardFilter{
@@ -87,18 +85,70 @@ func (c *grpcClient) updateFormat() *apiv2.UpdateFormat {
 			},
 		}},
 	}
-	eventFormat := &apiv2.EventFormat{Verbose: true}
+	ef := &apiv2.EventFormat{Verbose: true}
 	if c.readAsParty == "" {
-		eventFormat.FiltersForAnyParty = wildcard
+		ef.FiltersForAnyParty = wildcard
 	} else {
-		eventFormat.FiltersByParty = map[string]*apiv2.Filters{c.readAsParty: wildcard}
+		ef.FiltersByParty = map[string]*apiv2.Filters{c.readAsParty: wildcard}
 	}
+	return ef
+}
+
+// updateFormat wraps eventFormat in a LEDGER_EFFECTS transaction format, so
+// ExercisedEvents — which carry choice results — are included.
+func (c *grpcClient) updateFormat() *apiv2.UpdateFormat {
 	return &apiv2.UpdateFormat{
 		IncludeTransactions: &apiv2.TransactionFormat{
 			TransactionShape: apiv2.TransactionShape_TRANSACTION_SHAPE_LEDGER_EFFECTS,
-			EventFormat:      eventFormat,
+			EventFormat:      c.eventFormat(),
 		},
 	}
+}
+
+// GetActiveContracts reads the ACS snapshot at the current ledger end for the
+// client's read-as party. Scoping to a single party (e.g. "public") is how a
+// reader confirms it can see the contracts that party observes.
+func (c *grpcClient) GetActiveContracts(ctx context.Context) ([]ActiveContract, error) {
+	off, err := c.GetLedgerEnd(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := c.state.GetActiveContracts(ctx, &apiv2.GetActiveContractsRequest{
+		EventFormat:    c.eventFormat(),
+		ActiveAtOffset: off,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetActiveContracts: %w", err)
+	}
+	var out []ActiveContract
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("GetActiveContracts stream: %w", err)
+		}
+		// Skip incomplete (un)assigned entries; we only want created contracts.
+		ac := resp.GetActiveContract()
+		if ac == nil {
+			continue
+		}
+		ce := ac.GetCreatedEvent()
+		if ce == nil {
+			continue
+		}
+		tid := ce.GetTemplateId()
+		out = append(out, ActiveContract{
+			TemplateID: TemplateID{
+				PackageID:  tid.GetPackageId(),
+				ModuleName: tid.GetModuleName(),
+				EntityName: tid.GetEntityName(),
+			},
+			ContractID: ce.GetContractId(),
+		})
+	}
+	return out, nil
 }
 
 func (c *grpcClient) SubscribeUpdates(ctx context.Context, beginExclusive int64, tmpl TemplateID, choiceName string, out chan<- CantonMessageEvent) (*Subscription, error) {

--- a/node/pkg/watchers/canton/public_read_integration_test.go
+++ b/node/pkg/watchers/canton/public_read_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+// End-to-end test that a read-only "public" observer party can read the
+// core-bridge state over the real Ledger API v2 — proving public observability
+// at the participant layer, not just in in-memory Daml Script.
+//
+// It boots a sandbox, creates the CoreState/Emitter/EmitterIdentity (all observed
+// by a public party), then queries the active-contract set AS that public party
+// through the real cantonclient and confirms all three durable templates are
+// returned. Note: a dev sandbox is unauthenticated, so this exercises the
+// Ledger-API observer/read path for the public party; the participant-side
+// read-as-public authorization grant is a deployment concern (README §4.6).
+//
+//	go test -tags integration -run TestCantonPublicReadIntegration ./pkg/watchers/canton -v
+//
+// Requires `dpm` (PATH or ~/.dpm/bin) + a JDK; skipped otherwise. findDpm/runCmd
+// are shared with watcher_integration_test.go.
+package canton
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/cantonclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestCantonPublicReadIntegration(t *testing.T) {
+	dpm := findDpm(t)
+
+	cantonDir, err := filepath.Abs("../../../../canton")
+	require.NoError(t, err)
+	// The test DAR carries Test.TestCore:integrationPublicParty and packs core.
+	dar := filepath.Join(cantonDir, "test", ".daml", "dist", "wormhole-core-test-0.1.0.dar")
+
+	port := os.Getenv("CANTON_SANDBOX_PORT")
+	if port == "" {
+		port = "6865"
+	}
+	addr := "localhost:" + port
+
+	runCmd(t, cantonDir, dpm, "build", "--all")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sandboxDir := t.TempDir()
+	logPath := filepath.Join(sandboxDir, "sandbox.log")
+	logFile, err := os.Create(logPath)
+	require.NoError(t, err)
+	defer logFile.Close()
+
+	sandbox := exec.CommandContext(ctx, dpm, "sandbox", "--no-tty")
+	sandbox.Dir = sandboxDir
+	sandbox.Stdout = logFile
+	sandbox.Stderr = logFile
+	sandbox.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, sandbox.Start())
+	t.Cleanup(func() {
+		if sandbox.Process != nil {
+			_ = syscall.Kill(-sandbox.Process.Pid, syscall.SIGKILL)
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		b, _ := os.ReadFile(logPath)
+		return strings.Contains(string(b), "Canton sandbox is ready")
+	}, 180*time.Second, 2*time.Second, "sandbox never became ready")
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	require.NoError(t, err)
+	_ = conn.Close()
+
+	// Create CoreState + Emitter + EmitterIdentity (all observed by a public
+	// party) and return that public party.
+	partyFile := filepath.Join(sandboxDir, "public.json")
+	out, err := exec.Command(dpm, "script", "--dar", dar, "--upload-dar", "yes",
+		"--script-name", "Test.TestCore:integrationPublicParty",
+		"--ledger-host", "localhost", "--ledger-port", port,
+		"--output-file", partyFile).CombinedOutput()
+	require.NoErrorf(t, err, "dpm script failed: %s", out)
+
+	raw, err := os.ReadFile(partyFile)
+	require.NoError(t, err)
+	var publicParty string
+	require.NoError(t, json.Unmarshal(raw, &publicParty))
+	require.NotEmpty(t, publicParty)
+	t.Logf("reading ACS as public party: %s", publicParty)
+
+	// Read the ACS AS the public party through the real gRPC client.
+	client, err := cantonclient.NewCantonGrpcClient(addr, publicParty, zap.NewNop(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer client.Close()
+
+	acs, err := client.GetActiveContracts(ctx)
+	require.NoError(t, err)
+
+	// The public party must see all three durable core-bridge templates
+	// (all in module Wormhole.Core.State).
+	seen := map[string]bool{}
+	for _, ac := range acs {
+		if ac.TemplateID.ModuleName == publishMessageModule {
+			seen[ac.TemplateID.EntityName] = true
+		}
+	}
+	assert.True(t, seen["CoreState"], "public party should read CoreState")
+	assert.True(t, seen["Emitter"], "public party should read Emitter")
+	assert.True(t, seen["EmitterIdentity"], "public party should read EmitterIdentity")
+}

--- a/node/pkg/watchers/canton/watcher_test.go
+++ b/node/pkg/watchers/canton/watcher_test.go
@@ -46,6 +46,9 @@ func (f *fakeClient) SubscribeUpdates(_ context.Context, _ int64, _ cantonclient
 func (f *fakeClient) GetUpdateByOffset(_ context.Context, offset int64, _ cantonclient.TemplateID, _ string) (cantonclient.CantonTransaction, error) {
 	return f.byOffset[offset], nil
 }
+func (f *fakeClient) GetActiveContracts(_ context.Context) ([]cantonclient.ActiveContract, error) {
+	return nil, nil
+}
 func (f *fakeClient) Close() error { f.closeCalled = true; return nil }
 
 func testWatcher(msgC chan<- *common.MessagePublication) *Watcher {


### PR DESCRIPTION
## Summary

Adds a `public` observer party to the durable core-bridge contracts (`CoreState`, `Emitter`, `EmitterIdentity`) so their state is readable by any participant granted read-as rights for that party, without exposing any signing authority. The `public` party is sourced authoritatively from `CoreState` in `ApproveEmitter` so all emitter records are guaranteed to share one canonical visibility party.

## Changes

- **`canton/core/daml/Wormhole/Core/State.daml`** — `public : Party` added to `CoreState`, `Emitter`, and `EmitterIdentity`; listed as `observer` on each. `ApproveEmitter` fetches `public` from `CoreState` (operator is signatory) rather than accepting a requester-supplied value.
- **`canton/core/daml/Wormhole/Core/Setup.daml`** — `setup` allocates and stores the `public` party on `CoreState`.
- **`canton/devnet/bootstrap.sh`** — bootstrap passes the `public` party through to `setup`.
- **`canton/test/daml/Test/TestCore.daml`** — tests updated for the new `public` field; coverage added for public-read visibility.
- **`node/pkg/cantonclient/`** — `GetActiveContracts` added to the client interface and gRPC implementation to support public-read queries.
- **`node/pkg/watchers/canton/public_read_integration_test.go`** — new integration test verifying that contracts are visible when read as the `public` party.
- **`canton/README.md`** — §4.6 added documenting the public-readability design.
