### PR TITLE
canton: per-VAA replay protection

### DIFF
--- a/canton/README.md
+++ b/canton/README.md
@@ -133,8 +133,9 @@ digest = keccak256( keccak256( body ) )          // double keccak, Ethereum-styl
 ```
 
 Guardians sign `digest` with secp256k1 (Ethereum ECDSA, 65-byte `r‖s‖v`).
-Replay protection keys off `keccak256(body)` (the inner hash) exactly as
-elsewhere in Wormhole. The on-chain Daml verifier reconstructs and re-hashes the
+Replay protection keys off `digest` (the double keccak — EVM's `vm.hash`), both
+for governance (`consumedGovernance`, §4.4) and for integrator VAAs
+(`ConsumedVAA`, §4.6). The on-chain Daml verifier reconstructs and re-hashes the
 body and checks signatures against the stored guardian set (§5).
 
 `ChainID` for Canton is **72** (`ChainIDCanton`), the next free mainnet ID after
@@ -170,7 +171,7 @@ template CoreState
     guardianSetIndex   : Int            -- current set index
     guardianSets       : Map Int GuardianSet   -- index -> set (with expiry)
     messageFee         : Int            -- fee required to publish (native units)
-    consumedGovernance : Set Bytes32    -- replay protection (keyed by digest)
+    consumedGovernance : Set Bytes32    -- governance-only replay protection (§4.6)
   where
     signatory operator, guardianGovernance
     observer guardianObserver          -- read-only; sees governance transitions
@@ -423,6 +424,10 @@ against a live sandbox/participant
 a party with no relationship to `CoreState` at all — not `operator`, not
 `guardianGovernance` — verifies a real guardian-signed VAA as itself.
 
+Integrators that must consume a VAA (redeem exactly once) use
+`VerifyAndConsumeVAA` instead, which verifies **and** records consumption
+atomically (§4.6).
+
 ### 4.4 Governance
 
 Governance follows [0002](../whitepapers/0002_governance_messaging.md). A single
@@ -463,6 +468,100 @@ Matches EVM (`Setters.sol`): when a new set is installed, the previous set's
 `expirationTime` is set to `effectiveTime + 86400` (1 day). `verifyVAA` accepts a
 non-current set only while `effectiveTime < expirationTime`. The current set
 never expires.
+
+### 4.6 Per-VAA replay protection for integrators
+
+Governance replay protection is the `consumedGovernance` set inside `CoreState`
+(§4.4) — fine there, because governance actions are rare and already churn the
+singleton. App VAAs (token bridge / NTT) must **not** be recorded that way: Daml
+values have no structural sharing across contract updates, so an ever-growing
+set would be reserialized into every create node (payload size, participant DB
+write, and network cost all linear in history), and every integrator's consume
+would contend on the one singleton contract.
+
+Instead, consuming a VAA creates a dedicated contract — the Solana
+claim-account shape (`Replay.daml`):
+
+```haskell
+template ConsumedVAA
+  with
+    consumer : Party     -- integrator scope party; bears the replay risk
+    operator : Party     -- co-signs so the consumer cannot archive-and-replay
+    vaaHash  : Bytes32   -- double-keccak digest, same keying as consumedGovernance
+    ...                  -- emitter provenance (untrusted, for ops/debugging)
+  where
+    signatory consumer, operator
+    key (consumer, vaaHash) : (Party, Bytes32)
+    maintainer key._1
+```
+
+`VerifyAndConsumeVAA` (nonconsuming, on `CoreState`, flexible controller
+`consumer`) verifies the VAA (§5), fails if `(consumer, digest)` already has a
+guard (`lookupByKey`), and creates one. Integrators exercise it in the same
+transaction as the action the VAA authorizes, so verify + consume + act is
+atomic. The consumer must be able to see the `CoreState` to exercise — explicit
+disclosure or an observer party (Open Questions item 4).
+
+Properties:
+
+- **Uniqueness.** Contract keys are non-unique on Canton (§4.1), and key
+  lookups are **not maintainer-attested**: a lookup resolves against what the
+  _submission's readers_ can see (local contracts first, then disclosed ones,
+  then the readers' view). "At most one guard per (consumer, digest)" therefore
+  rests on three legs: every create flows through the vetted choice, which
+  looks up before creating (behavioral, like the `EmitterRegistry` id
+  discipline); every consuming submission carries the consumer's read view
+  (see the gotcha below); and the consumer is hosted on a single participant,
+  which then serializes its consumes. The trust is aligned: guardians never
+  re-check target-chain consumption — replay protection is the consumer's own
+  safety property, enforced on exactly the participant that bears the risk.
+- **No archive-and-replay.** The guard is created inside a `CoreState` choice
+  and inherits the `operator`'s signature, so it is co-signed: neither the
+  consumer nor the operator can archive it alone. Guards are never archived —
+  their permanence _is_ the replay protection.
+- **Scoping and contention.** Guards are scoped per consumer party: different
+  apps consume the same VAA independently, and distinct digests never contend
+  at all (the choice is nonconsuming). Cost per consume is one small, key-indexed
+  contract, forever — ACS growth is linear in consumed VAAs by design, the same
+  trade Solana makes with claim accounts.
+
+**Integrating — propose-accept, and why.** The executable reference is
+[`test/daml/Test/ExampleIntegrator.daml`](test/daml/Test/ExampleIntegrator.daml)
+(test package only). The recommended shape is **propose-accept**: the user
+creates a `RedeemRequest` with their sole signature (no disclosures, no read
+grants), and the manager's automation exercises `AcceptRedeem` — verify +
+consume + peer-check + mint, one atomic transaction, **submitted by the
+manager**. The `CoreState` disclosure is held by the manager's backend only;
+the redeemer's signature on the receipt is inherited from the archived
+request.
+
+The reason the *manager must submit* is a property of this key model, worth
+being explicit about. Key lookups are resolved once, on the submitting
+participant, against the submission's readers (local contracts → disclosed →
+reader-visible); the result is a pinned input to validation. Confirming
+participants re-check authorization, conformance, and the activeness of every
+contract the transaction _uses_ — but they do **not** re-run key lookups
+against their own stores (with non-unique keys and per-party visibility there
+is no canonical answer, and local re-checks would make validation
+nondeterministic and leak private state). So a _positive_ resolution is safe —
+it names a cid that is consistency-checked like any input — while a _negative_
+one names nothing and **fails open**. A negative lookup is sound only when the
+resolving view is complete by construction: the manager signs every guard of
+its app, so manager-as-submitter sees them all. A redemption submitted with
+only the user's view misses existing guards and double-consumes —
+`testReplayNeedsConsumerView` pins exactly that (two guards under one key) via
+a minimal `LookupProbe` template, deliberately not shaped like a flow. If that
+test ever starts failing, the ledger has tightened key semantics and this
+section should be revisited.
+
+User-*submitted* redemption (a flexible-controller choice exercised by the end
+user) is deliberately absent from the example: it is sound only when the
+submission carries the manager's read view — `readAs manager` through the
+app's participant, a per-API-user IAM grant exposing the manager's entire ACS.
+If user-submitted redemption is genuinely needed, scope the exposure instead:
+add a well-known public party as observer on `ConsumedVAA` and have users
+submit with `readAs public` (the Splice pattern), trading consumption metadata
+privacy for it.
 
 ---
 
@@ -685,12 +784,14 @@ canton/
     daml/Wormhole/Core/VAA.daml
     daml/Wormhole/Core/GuardianSet.daml
     daml/Wormhole/Core/State.daml
+    daml/Wormhole/Core/Replay.daml
     daml/Wormhole/Core/Governance.daml
     daml/Wormhole/Core/Setup.daml
   test/                          ← `wormhole-core-test` package (Daml Scripts)
     daml.yaml                    ← data-dependency on core's DAR
     daml/Test/TestCore.daml      ← unit tests + devnet `setup` / `integrationPublish`
     daml/Test/TestGuardianObserver.daml ← read-only guardianObserver visibility/authority tests
+    daml/Test/ExampleIntegrator.daml ← reference integrator + disclosure/replay e2e (§4.6)
   devnet/
     start_sandbox.sh             ← starts the Ledger API v2 sandbox
     bootstrap.sh                 ← allocates Operator + creates CoreState

--- a/canton/core/daml/Wormhole/Core/Replay.daml
+++ b/canton/core/daml/Wormhole/Core/Replay.daml
@@ -1,0 +1,55 @@
+-- | Per-VAA replay protection for integrators (token bridge / NTT).
+--
+-- Governance replay protection lives in 'Wormhole.Core.State.CoreState' as a
+-- @Set@ of consumed digests — fine there, because governance actions are rare
+-- and already churn the singleton. App VAAs are different: recording them in a
+-- shared @Set@ would (a) reserialize an ever-growing structure into every
+-- create node and (b) serialize ALL integrators' consumes through one
+-- contract. Instead, each consumed VAA gets its own small contract — the
+-- Solana claim-account shape — so distinct VAAs never contend and the cost per
+-- consume is one indexed row, forever.
+--
+-- UNIQUENESS / TRUST MODEL: contract keys are non-unique on Canton (see
+-- 'Wormhole.Core.State'), and key lookups are NOT maintainer-attested — a
+-- lookup resolves against what the SUBMISSION'S READERS can see (local
+-- contracts, then disclosed ones, then the readers' view; pinned by
+-- Test.ExampleIntegrator). "At most one 'ConsumedVAA' per (consumer, hash)"
+-- therefore rests on three legs:
+--   * every create flows through the vetted
+--     'Wormhole.Core.State.VerifyAndConsumeVAA' choice, which looks up before
+--     creating (behavioral, like the 'EmitterRegistry' id discipline);
+--   * every consuming submission carries the @consumer@'s read view — the
+--     only view guaranteed to contain all of its guards. Canonically the
+--     consumer's automation submits (propose-accept, see
+--     Test.ExampleIntegrator); @readAs consumer@ through its participant also
+--     works. A submission with only the consumer's inherited AUTHORITY but not
+--     its VISIBILITY misses existing guards and double-consumes;
+--   * the consumer is hosted on a single participant, which then serializes
+--     its consumes.
+-- The trust is aligned: guardians never re-check target-chain consumption, so
+-- replay protection is the consumer's own safety property, enforced on exactly
+-- the participant that bears the risk. The @operator@ co-signs (authority
+-- inherited from the 'CoreState' choice) so the consumer cannot unilaterally
+-- archive a guard and replay the VAA against its own users.
+module Wormhole.Core.Replay where
+
+import Wormhole.Core.Bytes
+
+-- | The replay guard: one active contract per consumed VAA, scoped to the
+-- consuming integrator party. Never archived — its permanence IS the replay
+-- protection. Keyed by @(consumer, vaaHash)@ where @vaaHash@ is the
+-- double-keccak digest ('Wormhole.Core.VAA.digestOf'), matching
+-- @consumedGovernance@ and the EVM @vm.hash@.
+template ConsumedVAA
+  with
+    consumer       : Party    -- integrator scope party; bears the replay risk
+    operator       : Party    -- co-signs so the consumer cannot archive-and-replay
+    vaaHash        : Bytes32  -- double-keccak digest of the VAA body
+    -- Emitter provenance, for ops/debugging only — never trusted, never keyed.
+    emitterChain   : Int
+    emitterAddress : Bytes32
+    sequence       : Int
+  where
+    signatory consumer, operator
+    key (consumer, vaaHash) : (Party, Bytes32)
+    maintainer key._1

--- a/canton/core/daml/Wormhole/Core/State.daml
+++ b/canton/core/daml/Wormhole/Core/State.daml
@@ -43,13 +43,14 @@ module Wormhole.Core.State where
 
 import DA.Map (Map)
 import DA.Map qualified as Map
-import DA.Optional (fromSomeNote)
+import DA.Optional (fromSomeNote, isNone)
 import DA.Set (Set)
 import DA.Set qualified as Set
 import DA.Time (addRelTime, seconds)
 import Wormhole.Core.Bytes
 import Wormhole.Core.GuardianSet
 import Wormhole.Core.Governance
+import Wormhole.Core.Replay
 import Wormhole.Core.VAA
 
 -- | The message record produced by 'PublishMessage'. This is the wire contract
@@ -97,7 +98,9 @@ template CoreState
     guardianSetIndex   : Int                -- index of the current set
     guardianSets       : Map Int GuardianSet
     messageFee         : Int                -- required fee (native units); 0 in v1
-    consumedGovernance : Set Bytes32        -- replay protection, keyed by digest
+    consumedGovernance : Set Bytes32        -- GOVERNANCE-ONLY replay protection, keyed by
+                                            -- digest; bounded by governance cadence. App VAAs
+                                            -- use per-VAA 'ConsumedVAA' guards instead.
   where
     -- Co-signed: the operator advances the singleton, but the guardianGovernance
     -- party co-signs so the operator cannot forge the guardian set (see module
@@ -145,6 +148,54 @@ template CoreState
         let signingSet = fromSomeNote "unknown guardian set index" (Map.lookup vaa.guardianSetIndex guardianSets)
         either assertFail pure (verifyVAA signingSet vaa pubKeys now)
         pure vaa
+
+    -- | Verify a VAA and record its consumption for @consumer@, atomically.
+    -- Integrators (token bridge / NTT) call this in the same transaction as the
+    -- action the VAA authorizes; the second consume of the same digest under
+    -- the same @consumer@ fails on the key lookup. Scoped per consumer: the
+    -- same VAA can be consumed by different integrator parties independently,
+    -- and distinct digests never contend (this choice is nonconsuming).
+    --
+    -- The controller is flexible, so the submitter needs to SEE this contract
+    -- to exercise — via explicit disclosure or an observer party (README "Open
+    -- Questions"). Creating the guard inside this choice is what gives it the
+    -- operator's co-signature (inherited authority), so the consumer cannot
+    -- archive it and replay.
+    --
+    -- SOUNDNESS: the guard lookup below resolves against the submission's
+    -- readers (key lookups are not maintainer-attested; a negative result is a
+    -- pinned validation input, so it fails OPEN), and it is complete only in
+    -- the consumer's read view — the consumer signs every one of its guards.
+    -- The consuming submission must therefore carry that view: canonically,
+    -- propose-accept, where the consumer's automation submits the accept (see
+    -- Test.ExampleIntegrator). The consumer's inherited authority alone does
+    -- not bring its visibility; without the view, the lookup misses existing
+    -- guards and double-consumes (pinned by
+    -- Test.ExampleIntegrator.testReplayNeedsConsumerView).
+    nonconsuming choice VerifyAndConsumeVAA : (VAA, ContractId ConsumedVAA)
+      with
+        encodedVAA : Bytes
+        pubKeys    : [(Int, Bytes)]
+        consumer   : Party
+      controller consumer
+      do
+        now <- getTime
+        let vaa = parseVAA encodedVAA
+        -- Like ParseAndVerifyVAA: any unexpired signing set is acceptable.
+        let signingSet = fromSomeNote "unknown guardian set index" (Map.lookup vaa.guardianSetIndex guardianSets)
+        either assertFail pure (verifyVAA signingSet vaa pubKeys now)
+        -- The consumer is the key maintainer, so its authority (the controller)
+        -- covers the lookup, and its participant serializes racing consumes.
+        existing <- lookupByKey @ConsumedVAA (consumer, vaa.hash)
+        assertMsg "VAA already consumed" (isNone existing)
+        guardCid <- create ConsumedVAA with
+          consumer
+          operator
+          vaaHash = vaa.hash
+          emitterChain = vaa.emitterChain
+          emitterAddress = vaa.emitterAddress
+          sequence = vaa.sequence
+        pure (vaa, guardCid)
 
     -- | Apply a governance VAA: verify it (against the CURRENT set, per EVM),
     -- check the governance emitter and replay protection, then dispatch.

--- a/canton/core/daml/Wormhole/Core/State.daml
+++ b/canton/core/daml/Wormhole/Core/State.daml
@@ -87,6 +87,21 @@ maxPayloadBytes = 750
 -- Core state singleton
 ----------------------------------------------------------------------
 
+-- | Shared verification core of 'ParseAndVerifyVAA' and 'VerifyAndConsumeVAA':
+-- parse, resolve the guardian set the VAA names, and verify signatures against
+-- it. A VAA may be signed by a non-current-but-unexpired set; 'verifyVAA'
+-- requires the named set to still be active. @pubKeys@ are untrusted hints
+-- bound to guardian addresses inside 'verifyVAA'. NOT used by
+-- 'SubmitGovernanceVAA', which deliberately accepts the CURRENT set only
+-- (EVM Governance.sol parity).
+verifyEncoded : CoreState -> Bytes -> [(Int, Bytes)] -> Update VAA
+verifyEncoded st encodedVAA pubKeys = do
+  now <- getTime
+  let vaa = parseVAA encodedVAA
+  let signingSet = fromSomeNote "unknown guardian set index" (Map.lookup vaa.guardianSetIndex st.guardianSets)
+  either assertFail pure (verifyVAA signingSet vaa pubKeys now)
+  pure vaa
+
 template CoreState
   with
     operator           : Party              -- advances the singleton; no power over outcomes
@@ -141,13 +156,7 @@ template CoreState
         pubKeys    : [(Int, Bytes)]
       controller verifier
       do
-        now <- getTime
-        let vaa = parseVAA encodedVAA
-        -- A VAA may be signed by a non-current-but-unexpired set; pick the set
-        -- it names and require it to still be active.
-        let signingSet = fromSomeNote "unknown guardian set index" (Map.lookup vaa.guardianSetIndex guardianSets)
-        either assertFail pure (verifyVAA signingSet vaa pubKeys now)
-        pure vaa
+        verifyEncoded this encodedVAA pubKeys
 
     -- | Verify a VAA and record its consumption for @consumer@, atomically.
     -- Integrators (token bridge / NTT) call this in the same transaction as the
@@ -179,11 +188,7 @@ template CoreState
         consumer   : Party
       controller consumer
       do
-        now <- getTime
-        let vaa = parseVAA encodedVAA
-        -- Like ParseAndVerifyVAA: any unexpired signing set is acceptable.
-        let signingSet = fromSomeNote "unknown guardian set index" (Map.lookup vaa.guardianSetIndex guardianSets)
-        either assertFail pure (verifyVAA signingSet vaa pubKeys now)
+        vaa <- verifyEncoded this encodedVAA pubKeys
         -- The consumer is the key maintainer, so its authority (the controller)
         -- covers the lookup, and its participant serializes racing consumes.
         existing <- lookupByKey @ConsumedVAA (consumer, vaa.hash)

--- a/canton/test/daml.yaml
+++ b/canton/test/daml.yaml
@@ -18,5 +18,9 @@ dependencies:
 build-options:
   # Daml-LF 2.3 (Protocol Version 35), matching wormhole-core.
   - --target=2.3
+  # Test.ExampleIntegrator deliberately defines reference templates in this
+  # test-only package (they must never ship in the core DAR); uploading this
+  # DAR — devnet only — drags daml-script along, which is acceptable there.
+  - -Wno-template-interface-depends-on-daml-script
 data-dependencies:
   - ../core/.daml/dist/wormhole-core-0.1.0.dar

--- a/canton/test/daml/Test/ExampleIntegrator.daml
+++ b/canton/test/daml/Test/ExampleIntegrator.daml
@@ -134,7 +134,7 @@ data IntegratorFixture = IntegratorFixture with
 
 setupIntegrator : Script IntegratorFixture
 setupIntegrator = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   manager <- allocateParty "ExampleManager"
   alice <- allocateParty "RedeemAlice"
   bob <- allocateParty "RedeemBob"

--- a/canton/test/daml/Test/ExampleIntegrator.daml
+++ b/canton/test/daml/Test/ExampleIntegrator.daml
@@ -1,0 +1,242 @@
+-- | A reference integrator (a mock NTT-manager shape) demonstrating how an app
+-- consumes a VAA atomically via 'VerifyAndConsumeVAA' (README §4.6).
+--
+-- The flow is PROPOSE-ACCEPT: the user creates a 'RedeemRequest' with their
+-- sole signature (no disclosures, no read grants), and the manager's
+-- automation exercises 'AcceptRedeem', which verifies the VAA, consumes it,
+-- checks the peer, and mints — one atomic transaction. The manager is the
+-- SUBMITTER of the consuming transaction, so the replay-guard lookup inside
+-- 'VerifyAndConsumeVAA' runs in the manager's read view, which provably
+-- contains every guard of this app (the manager signs them all) — the
+-- negative lookup is complete BY CONSTRUCTION, not by operational discipline.
+-- Authority flows the other way: the redeemer's signature on the receipt is
+-- inherited from the archived request. The 'CoreState' disclosure is needed
+-- only by the manager's backend, never by end users.
+--
+-- Why the manager must submit (pinned by 'testReplayNeedsConsumerView' below):
+-- keys are non-unique and lookups are NOT maintainer-attested. Resolution
+-- happens once, on the submitting participant, against the submission's
+-- readers (local contracts, then disclosed ones, then the readers' view), and
+-- the result is a pinned input to validation — no confirming participant
+-- re-runs it against its own store. A positive resolution names a cid that is
+-- checked for activeness like any input; a negative one names nothing and
+-- fails OPEN. A user-submitted consume would carry the manager's inherited
+-- AUTHORITY but not its VISIBILITY, miss existing guards, and double-consume.
+--
+-- Guardian signatures prove the VAA is real, NOT that it is addressed to this
+-- app: 'AcceptRedeem' checks the emitter against the registered peer before
+-- touching the payload.
+--
+-- This module ships in the TEST package only; it is a template for integrator
+-- packages, not part of the core DAR.
+module Test.ExampleIntegrator where
+
+import Daml.Script
+import DA.Assert ((===))
+import DA.Optional (fromSome)
+import Wormhole.Core.Bytes
+import Wormhole.Core.Replay
+import Wormhole.Core.Setup
+import Wormhole.Core.State
+import Test.TestCore (setup, govSetFeeVAA, devnetGuardianPubKey)
+
+-- | Stand-in for the integrator's real effect (a mint / unlock). Co-signed:
+-- the manager's authority comes from the accepting submission, the redeemer's
+-- is inherited from the archived 'RedeemRequest'.
+template RedeemReceipt
+  with
+    manager  : Party
+    redeemer : Party
+    sequence : Int
+    payload  : Bytes
+  where
+    signatory manager, redeemer
+
+-- | The app's configuration anchor: the replay scope and the registered peer.
+template ExampleIntegrator
+  with
+    manager     : Party    -- app party: signatory, and the replay scope
+    peerChain   : Int      -- registered source-chain peer of this app
+    peerAddress : Bytes32
+  where
+    signatory manager
+
+-- | The user's half of the propose-accept flow: created with the redeemer's
+-- sole signature and no special visibility. Withdrawable by the redeemer (the
+-- auto-generated Archive) until accepted.
+template RedeemRequest
+  with
+    redeemer   : Party
+    manager    : Party
+    encodedVAA : Bytes
+  where
+    signatory redeemer
+    observer manager
+
+    -- | The manager's half: verify + consume + peer-check + mint, one atomic
+    -- transaction, SUBMITTED BY THE MANAGER — its read view makes the guard
+    -- lookup complete, structurally. Consuming: the accepted request is
+    -- archived (redeemer's authority inherited from this contract), and that
+    -- same inherited authority co-signs the receipt. @pubKeys@ are the
+    -- submitter's untrusted hints, so they are supplied here, not by the user.
+    choice AcceptRedeem : ContractId RedeemReceipt
+      with
+        integratorCid : ContractId ExampleIntegrator
+        coreStateCid  : ContractId CoreState  -- disclosed to the manager's backend
+        pubKeys       : [(Int, Bytes)]
+      controller manager
+      do
+        integ <- fetch integratorCid
+        assertMsg "request addressed to a different manager" (integ.manager == manager)
+        (vaa, _guard) <- exercise coreStateCid VerifyAndConsumeVAA with
+          encodedVAA
+          pubKeys
+          consumer = manager
+        assertMsg "not from the registered peer"
+          (vaa.emitterChain == integ.peerChain
+            && normalizeHex vaa.emitterAddress == normalizeHex integ.peerAddress)
+        create RedeemReceipt with manager, redeemer, sequence = vaa.sequence, payload = vaa.payload
+
+-- | NOT an integration pattern — a minimal semantics probe backing the module
+-- header and README §4.6. Its one choice hands @anyone@ the consumer's
+-- inherited authority for a consume, without the consumer's read view. See
+-- 'testReplayNeedsConsumerView'.
+template LookupProbe
+  with
+    consumer : Party
+    anyone   : Party
+  where
+    signatory consumer
+    observer anyone
+
+    nonconsuming choice ProbeConsume : ()
+      with
+        coreStateCid : ContractId CoreState
+        encodedVAA   : Bytes
+        pubKeys      : [(Int, Bytes)]
+      controller anyone
+      do
+        _ <- exercise coreStateCid VerifyAndConsumeVAA with
+          encodedVAA
+          pubKeys
+          consumer
+        pure ()
+
+-- | Shared fixture: a bootstrapped bridge, one integrator app, and the
+-- CoreState disclosure the manager's backend attaches to accepts.
+data IntegratorFixture = IntegratorFixture with
+  operator : Party
+  csId     : ContractId CoreState
+  manager  : Party
+  users    : [Party]
+  intCid   : ContractId ExampleIntegrator
+  disc     : Disclosure
+
+setupIntegrator : Script IntegratorFixture
+setupIntegrator = do
+  (operator, csId) <- setup
+  manager <- allocateParty "ExampleManager"
+  alice <- allocateParty "RedeemAlice"
+  bob <- allocateParty "RedeemBob"
+  intCid <- submit manager do
+    createCmd ExampleIntegrator with
+      manager
+      -- govSetFeeVAA is emitted by (chain 1, 0x..04); register that as the peer.
+      peerChain = solanaGovernanceChainId
+      peerAddress = defaultGovernanceContract
+  -- A CoreState stakeholder (here the operator) exports the disclosure for the
+  -- manager's backend.
+  disc <- fromSome <$> queryDisclosure operator csId
+  pure IntegratorFixture with operator, csId, manager, users = [alice, bob], intCid, disc
+
+devnetPubKeys : [(Int, Bytes)]
+devnetPubKeys = [(0, devnetGuardianPubKey)]
+
+-- | End-to-end propose-accept redemption, the production shape: the user
+-- creates the request alone (no disclosures, no read grants); the manager's
+-- backend accepts with the CoreState disclosure attached, consuming the VAA in
+-- its own read view. Replays are then rejected at accept time for every
+-- requester of this app, while a second app remains its own replay scope.
+testIntegratorRedeem : Script ()
+testIntegratorRedeem = do
+  IntegratorFixture{csId, manager, users = [alice, bob], intCid, disc} <- setupIntegrator
+
+  -- The user's half needs nothing but her own signature.
+  reqCid <- submit alice do
+    createCmd RedeemRequest with redeemer = alice, manager, encodedVAA = govSetFeeVAA
+  let acceptArgs = AcceptRedeem with
+        integratorCid = intCid
+        coreStateCid = csId
+        pubKeys = devnetPubKeys
+
+  -- Even the manager cannot see the CoreState without the disclosure (it is
+  -- not a stakeholder): rejected.
+  submitMustFail (actAs manager) do exerciseCmd reqCid acceptArgs
+
+  -- The manager's backend accepts with the disclosure: verify + consume +
+  -- peer-check + mint, one transaction.
+  receiptCid <- submit (actAs manager <> disclose disc) do
+    exerciseCmd reqCid acceptArgs
+  Some receipt <- queryContractId alice receiptCid
+  receipt.sequence === 1
+  receipt.redeemer === alice
+  -- The request is consumed by the accept.
+  archived <- queryContractId alice reqCid
+  archived === None
+
+  -- The guard is scoped to the manager (not to alice).
+  [(_, guard)] <- query @ConsumedVAA manager
+  guard.consumer === manager
+
+  -- Replay: any further request for the same VAA is rejected at accept time —
+  -- the manager's view sees the guard, structurally.
+  reqCid2 <- submit bob do
+    createCmd RedeemRequest with redeemer = bob, manager, encodedVAA = govSetFeeVAA
+  submitMustFail (actAs manager <> disclose disc) do exerciseCmd reqCid2 acceptArgs
+
+  -- A second app is its own replay scope: the SAME VAA redeems there too.
+  manager2 <- allocateParty "ExampleManager2"
+  intCid2 <- submit manager2 do
+    createCmd ExampleIntegrator with
+      manager = manager2
+      peerChain = solanaGovernanceChainId
+      peerAddress = defaultGovernanceContract
+  reqCid3 <- submit alice do
+    createCmd RedeemRequest with redeemer = alice, manager = manager2, encodedVAA = govSetFeeVAA
+  receipt2Cid <- submit (actAs manager2 <> disclose disc) do
+    exerciseCmd reqCid3 AcceptRedeem with
+      integratorCid = intCid2
+      coreStateCid = csId
+      pubKeys = devnetPubKeys
+  Some receipt2 <- queryContractId alice receipt2Cid
+  receipt2.manager === manager2
+
+-- | THE FOOTGUN, pinned via 'LookupProbe': a consume submitted without the
+-- consumer's read view double-consumes. The guard lookup inside
+-- 'VerifyAndConsumeVAA' resolves against the submission's readers and its
+-- negative result is a pinned input to validation — no confirming participant
+-- re-checks it — so with only the submitter's view it misses the existing
+-- guard and a SECOND guard is created under the same key. This is why
+-- redemption flows must put the consumer in the submission (propose-accept).
+-- If this test ever starts failing, the ledger has tightened key semantics:
+-- revisit README §4.6.
+testReplayNeedsConsumerView : Script ()
+testReplayNeedsConsumerView = do
+  IntegratorFixture{csId, manager, users = [alice, _], disc} <- setupIntegrator
+  -- A sound consume first: the manager submits it itself.
+  _ <- submit (actAs manager <> disclose disc) do
+    exerciseCmd csId VerifyAndConsumeVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = devnetPubKeys
+      consumer = manager
+  -- Alice replays through the probe: the manager's AUTHORITY is inherited,
+  -- but the guard lookup runs in alice's view and misses.
+  probeCid <- submit manager do
+    createCmd LookupProbe with consumer = manager, anyone = alice
+  submit (actAs alice <> disclose disc) do
+    exerciseCmd probeCid ProbeConsume with
+      coreStateCid = csId
+      encodedVAA = govSetFeeVAA
+      pubKeys = devnetPubKeys
+  guards <- query @ConsumedVAA manager
+  length guards === 2   -- two guards, same key: the double-consume happened

--- a/canton/test/daml/Test/TestCore.daml
+++ b/canton/test/daml/Test/TestCore.daml
@@ -201,7 +201,7 @@ testParseAndVerifyVAA = do
 -- external verifiers" doc comment on the choice promises.
 testParseAndVerifyVAAByExternalVerifier : Script ()
 testParseAndVerifyVAAByExternalVerifier = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   tokenBridge <- allocateParty "ExternalTokenBridge"
   Some dCs <- queryDisclosure operator csId
   vaa <- submitWithDisclosures tokenBridge [dCs] do
@@ -222,7 +222,7 @@ testParseAndVerifyVAAByExternalVerifier = do
 -- it (a real, hosted party, not something forged).
 integrationParseAndVerifyVAAByExternalVerifier : Script Party
 integrationParseAndVerifyVAAByExternalVerifier = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   tokenBridge <- allocateParty "IntegrationExternalVerifier"
   Some dCs <- queryDisclosure operator csId
   vaa <- submitWithDisclosures tokenBridge [dCs] do
@@ -259,7 +259,7 @@ testGovernanceSetMessageFee = do
 -- production access path.
 testVerifyAndConsumeVAA : Script ()
 testVerifyAndConsumeVAA = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   ntt <- allocateParty "NttManager"
   disc <- fromSome <$> queryDisclosure operator csId
   (vaa, guardCid) <- submit (actAs ntt <> disclose disc) do
@@ -295,7 +295,7 @@ testVerifyAndConsumeVAA = do
 -- a resubmitted governance VAA.
 testGovernanceReplayRejected : Script ()
 testGovernanceReplayRejected = do
-  (operator, csId) <- setup
+  (operator, _, csId) <- setup
   Some cs0 <- queryContractId operator csId
   _ <- submit operator do
     exerciseByKeyCmd @CoreState cs0.guardianGovernance SubmitGovernanceVAA with

--- a/canton/test/daml/Test/TestCore.daml
+++ b/canton/test/daml/Test/TestCore.daml
@@ -11,6 +11,7 @@ import DA.Map qualified as Map
 import DA.Optional (fromSome)
 import Wormhole.Core.Bytes
 import Wormhole.Core.GuardianSet
+import Wormhole.Core.Replay ()   -- HasField instances for ConsumedVAA record-dot access
 import Wormhole.Core.State
 import Wormhole.Core.Setup
 import Wormhole.Core.VAA ()   -- HasField instances for VAA record-dot access
@@ -248,6 +249,62 @@ testGovernanceSetMessageFee = do
       pubKeys = [(0, devnetGuardianPubKey)]
   Some cs <- queryContractId operator newCsId
   cs.messageFee === 1000
+
+-- | Per-VAA replay protection: a consumer verifies-and-consumes a VAA once,
+-- creating the 'ConsumedVAA' guard; the second consume of the same digest is
+-- rejected on the key lookup. Scoping is per consumer (another party may
+-- consume the same VAA), and the guard is co-signed, so neither the consumer
+-- nor the operator can archive it alone. The consumer is not a 'CoreState'
+-- stakeholder — it exercises via explicit disclosure, which is also the
+-- production access path.
+testVerifyAndConsumeVAA : Script ()
+testVerifyAndConsumeVAA = do
+  (operator, csId) <- setup
+  ntt <- allocateParty "NttManager"
+  disc <- fromSome <$> queryDisclosure operator csId
+  (vaa, guardCid) <- submit (actAs ntt <> disclose disc) do
+    exerciseCmd csId VerifyAndConsumeVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+      consumer = ntt
+  Some guard <- queryContractId ntt guardCid
+  guard.vaaHash === vaa.hash
+  guard.emitterChain === 1
+  guard.sequence === 1
+
+  -- Replay under the same consumer is rejected.
+  submitMustFail (actAs ntt <> disclose disc) do
+    exerciseCmd csId VerifyAndConsumeVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+      consumer = ntt
+
+  -- A different consumer party has its own scope.
+  other <- allocateParty "OtherApp"
+  _ <- submit (actAs other <> disclose disc) do
+    exerciseCmd csId VerifyAndConsumeVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+      consumer = other
+
+  -- The guard is co-signed: neither party can archive-and-replay alone.
+  submitMustFail ntt do archiveCmd guardCid
+  submitMustFail operator do archiveCmd guardCid
+
+-- | Governance replay protection (the 'consumedGovernance' set) still rejects
+-- a resubmitted governance VAA.
+testGovernanceReplayRejected : Script ()
+testGovernanceReplayRejected = do
+  (operator, csId) <- setup
+  Some cs0 <- queryContractId operator csId
+  _ <- submit operator do
+    exerciseByKeyCmd @CoreState cs0.guardianGovernance SubmitGovernanceVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+  submitMustFail operator do
+    exerciseByKeyCmd @CoreState cs0.guardianGovernance SubmitGovernanceVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
 
 -- | Integration entrypoint, invoked by the Go integration test via
 -- `dpm script` (NOT by `dpm test`): set up the bridge, register an emitter,

--- a/cspell-custom-words.txt
+++ b/cspell-custom-words.txt
@@ -189,6 +189,8 @@ reobservations
 Reobservations
 reobserved
 repoint
+reserialize
+reserialized
 RLUSD
 runtimes
 rustup


### PR DESCRIPTION
## The problem

Replay protection currently lives in `CoreState` as a `Set` of consumed digests. On Canton this is the worst-case shape for an ever-growing structure: contracts are immutable, so every update archives the singleton and re-serializes the entire payload into the create node — there is no structural sharing between contract versions, no in-place mutation (as a Solana account would at least allow), and no sparse lazy access (as an EVM mapping provides). Cost per consume grows linearly with history across payload size, participant DB writes, and network bandwidth. Worse, because the `Set` lives in the one `CoreState` singleton, every consume in the system would contend on the same contract — a global throughput cap of one consume per sequencing round-trip.

For governance VAAs this is acceptable (they are rare, and already churn the singleton). For integrator traffic at NTT scale it is not — and until now there was no replay protection for integrator VAAs at all: `ParseAndVerifyVAA` verifies but records nothing.

## The solution

Consuming a VAA now creates a dedicated `ConsumedVAA` contract — the Solana claim-account shape. One small, key-indexed contract per consumed VAA, active forever; its permanence *is* the replay protection. Governance keeps the existing `Set`.

- **Scoped per consumer.** Guards are keyed `(consumer, digest)` where `consumer` is the integrator's party. Different apps consume the same VAA independently, and distinct digests never contend at all (`VerifyAndConsumeVAA` is nonconsuming). The trust is aligned: guardians never re-check target-chain consumption, so replay protection is the consumer's own safety property, enforced by the participant that bears the risk.
- **Atomic.** `VerifyAndConsumeVAA` on `CoreState` verifies guardian signatures, fails if a guard for `(consumer, digest)` exists, and creates one — in the same transaction as whatever the VAA authorizes. There is no window where a VAA is consumed but not acted on, or vice versa.
- **No archive-and-replay.** The guard is created inside a `CoreState` choice and inherits the operator's signature, so it is co-signed: neither the consumer nor the operator can archive it unilaterally.

## The subtlety: negative key lookups fail open

Canton contract keys (Daml-LF 2.3) are non-unique, and key lookups are **not maintainer-attested**: resolution happens once, on the submitting participant, against the submission's readers, and the result is a pinned input to validation. Confirming participants re-check authorization, conformance, and activeness of every contract a transaction *uses* — but a negative lookup names no contract, so nobody re-checks it against their own store. It fails open.

The consequence: the guard lookup is sound only when the resolving view provably contains every existing guard — and the only such view is the consumer's own (it signs all of them). Inherited *authority* does not bring inherited *visibility*: a redemption submitted with only an end user's view would miss existing guards and silently double-consume.

Integrations must therefore put the consumer in the submission. The reference integrator (`Test.ExampleIntegrator`) shows the recommended propose-accept shape: the user creates a `RedeemRequest` with their sole signature (no disclosures, no read grants), and the manager's automation accepts — verify + consume + peer-check + mint in one transaction, submitted by the manager, whose read view makes the negative lookup complete by construction. The `CoreState` itself is passed by contract id and made visible to the manager's backend via explicit disclosure.

The fail-open behavior itself is pinned by a dedicated probe test (`testReplayNeedsConsumerView`) that demonstrates the double-consume under an incomplete view; if it ever starts failing, the ledger has tightened key semantics and the documentation should be revisited.

## Caveat

The key-lookup semantics are pinned against the IDE ledger and match the stdlib's documented resolution order; confirming that a live Canton 3.5 participant treats pinned key inputs the same way is on the validation list, and the probe test is shaped to be re-run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)