### PR TITLE
canton: remove all contract keys

### DIFF
--- a/canton/README.md
+++ b/canton/README.md
@@ -9,10 +9,11 @@ client under [`node/pkg/cantonclient`](../node/pkg/cantonclient)).
 
 **Target deployment:** the **public Canton Network mainnet** — Canton **3.5.x**
 protocol, **Daml SDK 3.5.1** (Daml-LF **2.3**, Protocol Version **35**). Two
-consequences shape the design: Ledger API **v2**, and **contract keys that are
-non-unique** (Canton keys give stable lookup but do not enforce uniqueness — so
-identity uniqueness is registry-enforced and address integrity is cryptographic;
-see §1, §4).
+consequences shape the design: Ledger API **v2**, and **contract keys too weak
+to build on** (non-unique, resolved against the submitter's read view, negative
+lookups fail open) — the package uses **no contract keys**: contracts are
+addressed by contract-id, resolved off-ledger (§4.7); identity uniqueness is
+registry-enforced and address integrity is cryptographic (see §1, §4).
 
 The goal is parity with the canonical EVM core bridge
 ([`ethereum/contracts/Implementation.sol`](../ethereum/contracts/Implementation.sol),
@@ -72,17 +73,20 @@ The most consequential differences:
   Ethereum does. Guardian-set state on Canton therefore stores guardian
   **public keys** (not just their 20-byte addresses), bound to the canonical
   addresses from the governance VAA (§5).
-- **No global mutable singletons; contract keys are non-unique.** The "core
-  bridge contract" is modeled as a single long-lived **`CoreState`** contract,
-  archived and recreated on every governance transition. Contract keys exist on
-  Canton 3.5 (Daml-LF 2.3) but are **not unique** — multiple active contracts may
-  share a key ([docs](https://docs.canton.network/appdev/modules/m3-contract-keys#contract-keys)).
-  So keys give ergonomics (stable lookup / `ExerciseByKeyCommand`), not
-  uniqueness: the `CoreState` is **co-signed by the `operator` and a
-  `guardianGovernance` party** (a k-of-n threshold party) and keyed by the latter,
-  so the operator cannot forge the guardian set (§4.1); per-emitter uniqueness is
-  a **registry** that allocates ids plus an owner-bound, cryptographic address
-  (§4.2).
+- **No global mutable singletons; no contract keys.** The "core bridge
+  contract" is modeled as a single long-lived **`CoreState`** contract, archived
+  and recreated on every governance transition. Contract keys exist on Canton
+  3.5 (Daml-LF 2.3) but are **not unique** — multiple active contracts may share
+  a key ([docs](https://docs.canton.network/appdev/modules/m3-contract-keys#contract-keys))
+  — and lookups resolve against the submission's readers, with negative results
+  failing open (§4.6). They can carry neither uniqueness nor authenticity, so
+  this package uses none: contracts are addressed **by contract-id**, resolved
+  from a stakeholder's own ACS or via the disclosure service (§4.7), and
+  authenticated by their **payloads** (signatories cannot be forged). The
+  `CoreState` is **co-signed by the `operator` and a `guardianGovernance`
+  party** (a k-of-n threshold party), so the operator cannot forge the guardian
+  set (§4.1); per-emitter uniqueness is a **registry** that allocates ids plus
+  an owner-bound, cryptographic address (§4.2).
 
 ---
 
@@ -175,8 +179,6 @@ template CoreState
   where
     signatory operator, guardianGovernance
     observer guardianObserver          -- read-only; sees governance transitions
-    key guardianGovernance : Party   -- lookup by the governance anchor is authentic
-    maintainer key
 ```
 
 **Read-only guardian observer.** `guardianObserver` is a template `observer`
@@ -198,22 +200,22 @@ archives the current `CoreState`, and `create`s the next one with updated fields
 This is the Daml idiom for mutable state and gives us deterministic,
 replay-protected transitions.
 
-**Singleton co-signed by a governance party, keyed for authenticity.** The
-`CoreState` is co-signed by the `operator` and a **`guardianGovernance`** party.
-In production that is a **decentralized-namespace external party** controlled by a
-k-of-n threshold of guardian keys — the same construction as the Canton Network's
-DSO party — rotated at the topology layer without touching this template (the
-party id, and thus the key and every consumer's lookup, is stable across guardian
-rotation). Two things follow:
+**Singleton co-signed by a governance party; authenticity is in the payload.**
+The `CoreState` is co-signed by the `operator` and a **`guardianGovernance`**
+party. In production that is a **decentralized-namespace external party**
+controlled by a k-of-n threshold of guardian keys — the same construction as
+the Canton Network's DSO party — rotated at the topology layer without touching
+this template (the party id, and thus every consumer's trust anchor, is stable
+across guardian rotation). Two things follow:
 
-- **The operator cannot forge the guardian set.** Because `guardianGovernance` is
-  a signatory *and* the key maintainer, a compromised operator cannot `create` a
-  `CoreState` bearing the real governance party — so a lookup by the known
-  `guardianGovernance` party (`fetchByKey`/`ExerciseByKeyCommand`) can only ever
-  resolve an **authentic** `CoreState`. Its guardian set is thus cryptographically
-  anchored, not operator-controlled. (Keys are still non-unique, so an operator
-  puppet could create a `CoreState` under a *different* governance party — but it
-  is not findable by the real anchor and no consumer trusts it.)
+- **The operator cannot forge the guardian set.** Because `guardianGovernance`
+  is a signatory, a compromised operator cannot `create` a `CoreState` bearing
+  the real governance party — so any fetched or disclosed `CoreState` whose
+  `guardianGovernance` (or `operator`) field is the known anchor party is
+  **authentic by construction**, however its cid was obtained. Consumers
+  authenticate the payload, never the resolution path (§4.7). An operator
+  puppet could create a `CoreState` under a *different* governance party — but
+  its payload names the wrong parties and no consumer trusts it.
 - **Governance stays low-friction.** `guardianGovernance` actively signs only at
   **genesis**; each `SubmitGovernanceVAA` transition inherits its authority from
   the archived contract (the same authority-propagation as the `Emitter` owner
@@ -244,21 +246,17 @@ config and governance state.
 Mirrors `publishMessage(nonce, payload, consistencyLevel)` from
 `Implementation.sol:15` and whitepaper 0004.
 
-An integrator first registers an emitter. The operator runs an `EmitterRegistry`
-(created at setup, keyed by the operator) that allocates a stable integer id;
-`ApproveEmitter` allocates one and creates the keyed `Emitter` in one transaction:
+An integrator first registers an emitter — **directly, with no operator
+involvement**. The operator runs an `EmitterRegistry` (created at setup); the
+requester exercises `RegisterEmitter` on it, holding only the registry's
+disclosure (§4.7). The flexible controller brings the requester's signature;
+the operator's co-signature on the created `Emitter` is *inherited* from the
+registry's signatory — the same authority-inheritance that powers
+`VerifyAndConsumeVAA`. Registration is permissionless (EVM/Sui parity: anyone
+may emit); the choice is consuming, so racing registrations contend on the
+registry and the loser retries with the fresh cid:
 
 ```haskell
-template EmitterRequest with
-    requester : Party
-    operator  : Party
-  where
-    signatory requester
-    observer operator
-    -- operator exercises ApproveEmitter, which allocates an emitterId from the
-    -- EmitterRegistry and creates the keyed Emitter in one transaction. The
-    -- requester's signature on this request authorizes the owner co-signatory.
-
 -- One per operator; allocates monotonically increasing emitter ids.
 template EmitterRegistry with
     operator         : Party
@@ -266,32 +264,27 @@ template EmitterRegistry with
     nextId           : Int
   where
     signatory operator
-    key operator : Party
-    maintainer key
     -- guardianObserver is a FIELD only here, NOT a template observer: guardians
     -- watch the attestation surface, not id allocation (least privilege).
-    -- choice AllocateEmitterId : (ContractId EmitterRegistry, Int, Party)
-    --   -- result carries guardianObserver so ApproveEmitter threads it into the
-    --   -- new Emitter from this single key resolution.
+    -- choice RegisterEmitter : (ContractId EmitterRegistry, ContractId Emitter)
+    --   with requester : Party
+    --   controller requester   -- operator authority inherited; no crank
 
 template Emitter
   with
     operator         : Party
     owner            : Party
     guardianObserver : Party   -- read-only guardian observer (stakeholder, never signs)
-    emitterId        : Int      -- registry-allocated; key._3
+    emitterId        : Int      -- registry-allocated
     emitterAddress   : Bytes32  -- keccak256(tag ‖ operator ‖ owner ‖ emitterId), set at creation
     sequence         : Int      -- next sequence to assign (per-emitter)
   where
     signatory operator, owner   -- owner co-signs: the msg.sender analog
     observer guardianObserver   -- read-only; sees PublishMessage (consuming)
-    key (operator, owner, emitterId) : (Party, Party, Int)
-    maintainer key._1
 ```
 
-The `guardianObserver` is threaded in at registration: `ApproveEmitter`
-resolves the `EmitterRegistry` once (`AllocateEmitterId`, whose result now
-carries the party) and sets the field on the created `Emitter`. Because
+The `guardianObserver` is threaded in at registration: `RegisterEmitter` sets
+the registry's field on the created `Emitter`. Because
 `PublishMessage` is consuming, the observer is an informee of every publish
 exercise (and its `WormholeMessage` result) plus the sequence-bumped successor
 `Emitter` create — the full message surface — with no authority (§4.1, §10).
@@ -346,18 +339,19 @@ choice PublishMessage : WormholeMessage
 ```
 
 The choice's **exercise result** is the `WormholeMessage`. The sequence-bumped
-`Emitter` is recreated under the **same key** (both signatures inherited from the
-consumed contract), so the owner publishes again via
-`exerciseByKey`/`ExerciseByKeyCommand` — no contract-id tracking. The watcher
-reads the result directly from the `ExercisedEvent.exercise_result` on the
-Ledger-API stream (see §7). The `WormholeMessage` record is the wire contract
-between Daml and the watcher:
+`Emitter` is recreated with both signatures inherited from the consumed
+contract; the owner is a signatory, so the successor's **cid arrives on its own
+ACS** as the transaction's `CreatedEvent`, and the next publish addresses that
+cid directly — stakeholders never need an off-ledger resolver (§4.7). The
+watcher reads the result directly from the `ExercisedEvent.exercise_result` on
+the Ledger-API stream (see §7). The `WormholeMessage` record is the wire
+contract between Daml and the watcher:
 
 ```haskell
 data WormholeMessage = WormholeMessage with
-    registrar        : Party     -- Emitter key._1 (operator); address input
-    owner            : Party     -- Emitter key._2; address input (anti-impersonation)
-    emitterId        : Int       -- Emitter key._3 (registry-allocated); address input
+    registrar        : Party     -- the operator; address input
+    owner            : Party     -- the emitting party; address input (anti-impersonation)
+    emitterId        : Int       -- registry-allocated; address input
     sequence         : Int       -- uint64
     nonce            : Int       -- uint32
     consistencyLevel : Int       -- uint8
@@ -570,10 +564,11 @@ service indexes the consumer's active nodes by prefix (following the
 the covering node's cid plus its explicit disclosure — alongside the
 `CoreState` disclosure it already serves (§4.3). It is **untrusted for
 safety**: the worst it can do is serve a wrong or stale node, which fails the
-transaction. It is trusted for *liveness* only, like any RPC endpoint. (Go
-implementation is future work; the Daml tests simulate it with a script
-helper, `Test.TestReplay.coveringNode`, which also asserts the partition
-invariant on every use.)
+transaction. It is trusted for *liveness* only, like any RPC endpoint. §4.7
+aggregates every resolution the service must provide. (Go implementation is
+future work; the Daml tests simulate it with a script helper,
+`Test.TestReplay.coveringNode`, which also asserts the partition invariant on
+every use.)
 
 **Integrating — direct and user-submitted.** The executable reference is
 [`test/daml/Test/ExampleIntegrator.daml`](test/daml/Test/ExampleIntegrator.daml)
@@ -585,6 +580,56 @@ its *visibility* is simply not needed. `testIntegratorRedeem` pins the
 inversion of the key-based design's failure mode: replay attempts by arbitrary
 submitters fail on activeness (stale node) or membership (fresh node) — never
 succeed.
+
+### 4.7 Addressing without keys: the disclosure service
+
+With contract keys gone (§1), every contract reference is a **contract-id**.
+Two distinct needs hide behind "how do I find the contract", and they have
+different answers:
+
+- **Cid resolution** — *what is the current cid of X?* Stakeholders get this
+  for free: a consuming exercise delivers the successor's `CreatedEvent` to
+  every stakeholder's ACS, so the operator tracks its registries and the
+  `CoreState`, an emitter owner tracks its `Emitter`, a consumer tracks its
+  trie — all without any off-ledger help.
+- **Disclosure attachment** — a **non-stakeholder** submitter must additionally
+  attach the explicit-disclosure blob of every contract its transaction
+  references, or its participant cannot construct the transaction at all.
+
+The **disclosure service** is the single off-ledger component that provides
+both to parties that need them: an index over the relevant contracts — fed by
+the Ledger API update stream / ACS of a party that sees them — answering
+"current cid (+ disclosure blob) for X". The complete inventory of resolutions
+it must serve:
+
+| Contract                | Index                              | Needed by                                                     | Disclosure attachment?                          | Churn                        |
+| ----------------------- | ---------------------------------- | ------------------------------------------------------------- | ----------------------------------------------- | ---------------------------- |
+| `CoreState`             | the one true instance              | integrators/users exercising §4.3 verify or §4.6 consume       | yes — every non-stakeholder submitter           | per governance action (rare) |
+| `ReplayNode`            | (consumer, prefix covering digest) | every `VerifyAndConsumeVAA` / integrator redeem                | yes for non-stakeholders (e.g. end users); the consumer itself only needs the cid | every consume under that node |
+| `EmitterRegistry`       | operator                           | `RegisterEmitter`                                              | yes — the requester submits                     | per emitter registration     |
+| `ReplayRootRegistry`    | operator                           | `ApproveReplayRoot`                                            | no — operator submits, own ACS                  | per root grant               |
+| `Emitter`               | (operator, owner, emitterId)       | `PublishMessage`                                               | no — owner submits, own ACS                     | per publish                  |
+| app contracts (e.g. `ExampleIntegrator`) | app-defined      | the app's own choices                                          | app's concern (its users are observers)         | app-defined                  |
+
+Two properties make this safe to outsource:
+
+- **Untrusted for safety.** A wrong or stale answer can only make the
+  transaction fail — the trie fails closed on staleness (§4.6), and consumers
+  authenticate every resolved contract by its **payload**, never by how the
+  cid was found: `CoreState` by its signatory anchor fields (§4.1),
+  `ReplayNode` by the (consumer, operator) binding inside `VerifyAndConsumeVAA`
+  plus the app-side operator pin (see `ExampleIntegrator.Redeem`). The service
+  is trusted for *liveness* only, like any RPC endpoint.
+- **One reader suffices.** A service reading as the operator (a stakeholder of
+  `CoreState`, both registries, and — as co-signatory — every consumer's trie)
+  can serve the whole table; integrators can equally run their own for their
+  trie and app contracts. Reading as a party requires only that party's
+  `CanReadAs` on the serving participant.
+
+Concrete implementation (interface: `(template, index) → (cid,
+created_event_blob)` over the state-service ACS plus the update stream) is
+future work; the Daml tests simulate it with `Test.TestReplay.coveringNode` /
+`queryDisclosure`.
 
 ---
 
@@ -1027,7 +1072,7 @@ participant independently receives and validates every attestation-bearing
 transaction, and an invalid one never appears on that participant's Ledger API —
 so a watcher cannot sign it. This is deliberately scoped to the **attestation
 surface only** (§4.1, §4.2): the observer is *not* a stakeholder of
-`EmitterRequest`s, `EmitterRegistry` allocations, or any holding/balance/transfer
+`EmitterRegistry` allocations, replay tries, or any holding/balance/transfer
 state of other packages — least privilege, in contrast to replica-hosting the
 `operator` (whose projection is its entire signatory footprint; kept as a
 fallback below). A single shared `guardianObserver` covers all guardians (one
@@ -1047,13 +1092,14 @@ the quorum and turn guardian downtime into a chain-halt).
 > **Fallback (interim, no template change):** where a participant cannot yet host
 > the dedicated party, replica-host the `operator` at `Observation` instead. It
 > works with zero Daml change but gives a coarser scope (the operator's full
-> projection, including `EmitterRequest`s) and couples guardian read access to the
-> operator party and its namespace key. Prefer the dedicated `guardianObserver`;
-> use operator replica-hosting only as a migration stopgap.
+> projection, including registries and replay tries) and couples guardian read
+> access to the operator party and its namespace key. Prefer the dedicated
+> `guardianObserver`; use operator replica-hosting only as a migration stopgap.
 
 **What a compromised operator can and cannot do.** It can degrade **liveness**
-(stop approving registrations, stop relaying, evict observers — all fail-safe:
-guardians then simply stop seeing and stop signing). It **cannot** produce
+(stop serving disclosures, stop granting replay roots, evict observers — all
+fail-safe: transactions stop constructing, guardians simply stop seeing and
+stop signing). It **cannot** produce
 anything guardians would wrongly attest: emitting under an existing address
 requires that owner's signature (§4.2), so an outbound forge is either an invalid
 transaction (rejected in replay, never observed) or a valid contract with a
@@ -1061,8 +1107,8 @@ different, untrusted address.
 
 Crucially, it also **cannot forge the guardian set** used for inbound
 verification: `CoreState` is co-signed by the `guardianGovernance` threshold party
-and keyed by it (§4.1), so the operator can neither mutate the real `CoreState`
-nor fabricate one that a consumer would find by the governance anchor. This closes
+(§4.1), so the operator can neither mutate the real `CoreState` nor fabricate
+one whose payload names the governance anchor consumers trust. This closes
 the one gap that observation-only hosting does *not* cover — inbound state
 integrity — by moving it from "trust the single operator" to "trust the k-of-n
 governance party." Compromising *that* is a threshold compromise, i.e. genuinely
@@ -1091,8 +1137,8 @@ human decision; see Open Questions.
    shift slightly across Canton releases (e.g. `begin_exclusive`/`end_inclusive`,
    `Update` one-of members). The vendored proto subset targets a specific release
    — confirm and pin against Daml SDK 3.5.1 / Canton 3.5.x.
-2. **`guardianGovernance` threshold party.** `CoreState` is co-signed by and keyed
-   on a `guardianGovernance` party (§4.1), so guardian-set integrity is anchored to
+2. **`guardianGovernance` threshold party.** `CoreState` is co-signed by a
+   `guardianGovernance` party (§4.1), so guardian-set integrity is anchored to
    it rather than the operator. §9's `guardianGovernance` external-party bootstrap
    stands it up as a decentralized-namespace external party governed by a 2-of-3
    threshold of guardian keys (DSO-style), and its genesis co-sign ceremony is
@@ -1126,8 +1172,7 @@ human decision; see Open Questions.
    initially (`messageFee = 0`).
 6. **ContractUpgrade mechanism.** Confirm the operator-driven Daml package
    upgrade flow and how strictly the recorded target package-id should gate it.
-   Note contract keys **cannot** be added to an already-deployed template via
-   smart-contract upgrade, so this keyed design must land before any mainnet
-   deployment of the templates.
+   (The package uses no contract keys, so the upgrade constraint that keys
+   cannot be added to a deployed template does not apply.)
 7. **Governance emitter.** Uses the standard governance emitter (Solana, chain 1,
    address `0x00..04`). Confirm for the target deployment/network.

--- a/canton/README.md
+++ b/canton/README.md
@@ -529,23 +529,36 @@ the digest — verify + consume + act in one transaction.
 
 Properties:
 
-- **No archive-and-replay, no shadow roots.** Archival alone only bricks
-  (fail-closed); the replay vector is node *re-creation*. Nodes are co-signed,
-  so neither the consumer nor the operator can archive or create one alone;
-  splits inherit both signatures from the archived parent (the operator is not
-  involved per consume). Roots are granted exactly once per consumer through
-  the operator's `ReplayRootRegistry` — a *positive*, on-ledger
-  one-root-per-consumer check (the registry carries the granted set and every
-  grant consumes it), via a one-time propose-accept ceremony
-  (`ReplayRootRequest`), mirroring emitter registration. The irreducible
-  remainder: consumer and operator *colluding* can rebuild a trie —
-  signatories can always unmake their own contracts.
+- **Nobody can touch someone else's scope; your own scope is your own
+  problem.** Archival alone only bricks (fail-closed); the replay vector is
+  node *re-creation*. Nodes are co-signed, so no third party can archive or
+  re-create them (splits inherit both signatures from the archived parent —
+  the operator is not involved per consume), and roots come only from the
+  operator's `ReplayRootRegistry` — a stateless, never-churning anchor whose
+  nonconsuming `ClaimReplayRoot` lends the operator's *inherited* signature
+  to a consumer-submitted claim (the `RegisterEmitter` pattern: no crank; the
+  operator multisig signs nothing after genesis). Claiming a root for a
+  consumer requires **that consumer's authority**, so nobody can fork another
+  app's replay scope. There is deliberately *no* one-root-per-consumer
+  enforcement: maintaining a single trie is the consumer's own responsibility
+  (its disclosure service defines which trie its consumes resolve into, and
+  detects forks — more than one covering node — for free). This is EVM
+  parity: nobody grants replay storage there either; every integrator owns
+  its mapping. A consumer minting parallel roots, like a consumer whose key
+  is stolen, only harms itself — and a stolen consumer key defeats the app
+  more directly anyway. (If key-compromise resilience is ever wanted, the
+  hardening is trie-identity pinning: thread the original root's cid through
+  successors via `self` and pin it in the app contract — documented, not
+  built.) Spam claims cost the spammer synchronizer traffic per transaction
+  and the operator ~300 B of storage per worthless root; no shared contract
+  grows, nothing bricks.
 - **Scoping and contention.** Tries are per consumer party: different apps
   consume the same VAA independently. Consumes racing on the *same node*
   conflict — exactly one commits (validator-checked, regardless of submitter);
   the loser re-resolves the covering node and retries. A blind retry of a
-  consume that actually committed fails on membership ("VAA already consumed")
-  — a clean idempotency signal. Until the first split, all of one app's
+  consume that actually committed fails on membership ("digest already
+  consumed") — a clean idempotency signal. Until the first split, all of one
+  app's
   consumes serialize through its root; 16-way fan-out begins at
   `splitThreshold` consumes.
 - **Cost.** `defaultSplitThreshold = 128`: suffixes are ≤64-char hex (~66 B
@@ -607,7 +620,7 @@ it must serve:
 | `CoreState`             | the one true instance              | integrators/users exercising §4.3 verify or §4.6 consume       | yes — every non-stakeholder submitter           | per governance action (rare) |
 | `ReplayNode`            | (consumer, prefix covering digest) | every `VerifyAndConsumeVAA` / integrator redeem                | yes for non-stakeholders (e.g. end users); the consumer itself only needs the cid | every consume under that node |
 | `EmitterRegistry`       | operator                           | `RegisterEmitter`                                              | yes — the requester submits                     | per emitter registration     |
-| `ReplayRootRegistry`    | operator                           | `ApproveReplayRoot`                                            | no — operator submits, own ACS                  | per root grant               |
+| `ReplayRootRegistry`    | operator                           | `ClaimReplayRoot`                                              | yes — the consumer submits (static blob, cacheable) | never (stateless anchor)     |
 | `Emitter`               | (operator, owner, emitterId)       | `PublishMessage`                                               | no — owner submits, own ACS                     | per publish                  |
 | app contracts (e.g. `ExampleIntegrator`) | app-defined      | the app's own choices                                          | app's concern (its users are observers)         | app-defined                  |
 
@@ -1096,10 +1109,16 @@ the quorum and turn guardian downtime into a chain-halt).
 > access to the operator party and its namespace key. Prefer the dedicated
 > `guardianObserver`; use operator replica-hosting only as a migration stopgap.
 
+Note the operator party's ACTIVE signing surface after genesis is empty: every
+day-to-day flow (`RegisterEmitter`, `ClaimReplayRoot`, splits, governance
+transitions) reaches its signature by inheritance from contracts it signed at
+setup. If the operator is stood up as a k-of-n external threshold party (the
+§9 machinery, `GG_THRESHOLD=k`), the interactive-submission signing ceremony
+is needed for genesis only.
+
 **What a compromised operator can and cannot do.** It can degrade **liveness**
-(stop serving disclosures, stop granting replay roots, evict observers — all
-fail-safe: transactions stop constructing, guardians simply stop seeing and
-stop signing). It **cannot** produce
+(stop serving disclosures, evict observers — all fail-safe: transactions stop
+constructing, guardians simply stop seeing and stop signing). It **cannot** produce
 anything guardians would wrongly attest: emitting under an existing address
 requires that owner's signature (§4.2), so an outbound forge is either an invalid
 transaction (rejected in replay, never observed) or a valid contract with a

--- a/canton/core/daml/Wormhole/Core/Bytes.daml
+++ b/canton/core/daml/Wormhole/Core/Bytes.daml
@@ -131,8 +131,8 @@ data RegistrarText = RegistrarText Text deriving (Eq, Show)
 data OwnerText     = OwnerText     Text deriving (Eq, Show)
 data RegistryId    = RegistryId    Int  deriving (Eq, Show)
 
--- | Canonical 32-byte registry address, keyed off the components of a
--- registry-allocated contract key:
+-- | Canonical 32-byte registry address, derived from the components of a
+-- registry-allocated identity:
 --
 -- > keccak256( utf8(tag) ‖ lp(utf8(registrar)) ‖ lp(utf8(owner)) ‖ uint64be(id) )
 --

--- a/canton/core/daml/Wormhole/Core/Replay.daml
+++ b/canton/core/daml/Wormhole/Core/Replay.daml
@@ -35,16 +35,18 @@
 -- its subspace — no covering node, nothing verifies — fail-closed, the
 -- opposite of the key model.
 --
--- The replay vector is therefore node RE-CREATION (archive-and-recreate, or a
--- parallel shadow root), which the signatory design closes: the @operator@
--- co-signs every node, so the consumer alone can neither archive nor create
--- one, and roots are granted exactly once per consumer through the
--- 'ReplayRootRegistry' — a positive, on-ledger one-root-per-consumer check
--- linearized by consuming the registry (the 'EmitterRegistry' pattern, minus
--- the key). Splits inherit both signatures from the archived parent, so the
--- operator is not involved per consume. The irreducible remainder: consumer
--- and operator COLLUDING can archive and rebuild a trie — signatories can
--- always unmake their own contracts.
+-- The replay vector is therefore node RE-CREATION. Against THIRD PARTIES the
+-- signatory design closes it: the @operator@ co-signs every node (inherited
+-- from the 'ReplayRootRegistry' anchor at the root, from the archived parent
+-- at splits — the operator never signs per consume), and claiming a root for
+-- a consumer requires that consumer's authority, so nobody can archive,
+-- re-create, or fork someone ELSE'S replay scope. Against the consumer
+-- ITSELF there is deliberately no on-ledger defense: a consumer can mint
+-- parallel roots for its own scope (see 'ReplayRootRegistry'), which is
+-- self-harm — replay protection is the consumer's own safety property, and a
+-- compromised consumer key defeats the app more directly anyway. Same class
+-- as the irreducible signatory remainder: signatories can always unmake (or
+-- here, duplicate) their own state.
 --
 -- OFF-LEDGER: consumers (and their users) locate the covering node for a
 -- digest via a disclosure service — an ACS index over (consumer, prefix) that
@@ -53,7 +55,7 @@
 -- RETRY PROTOCOL: racing consumes on the same node conflict and exactly one
 -- commits; on rejection, re-resolve the covering node (the cid churns on every
 -- consume) and resubmit. A blind retry of a consume that actually committed
--- hits the membership check and fails "VAA already consumed" — a clean
+-- hits the membership check and fails "digest already consumed" — a clean
 -- idempotency signal.
 module Wormhole.Core.Replay where
 
@@ -123,7 +125,7 @@ template ReplayNode
         -- The replay check MUST precede the split branch: a split inserting a
         -- duplicate would be a silent Set.insert no-op — a replay that
         -- "succeeds".
-        assertMsg "VAA already consumed" (not (Set.member suffix consumed))
+        assertMsg "digest already consumed" (not (Set.member suffix consumed))
         if Set.size consumed < splitThreshold || T.length prefix == 63
           -- Depth-63 nodes never split: suffixes are single nibbles (≤16
           -- distinct, so the set is bounded), and children would be degenerate
@@ -143,51 +145,41 @@ template ReplayNode
               Some cid -> pure cid
               None -> abort "unreachable: split lost the covering child"
 
--- | Grants each consumer AT MOST ONE trie root — the positive, on-ledger
--- uniqueness check that a contract key cannot provide. One registry per
--- operator, created at setup ('mkInitialReplayRootRegistry'); every grant
--- consumes it, so grants are linearized through the operator. The set grows by
--- one Party per integrator app — dozens, not millions.
+-- | Hands out trie roots to any consumer that asks — a stateless O(1) anchor
+-- whose one nonconsuming choice lends the operator's INHERITED co-signature to
+-- consumer-submitted claims (the 'RegisterEmitter' pattern): no operator
+-- crank, no contention, no churn — the registry's disclosure blob is static
+-- and cacheable. One per operator, created at setup
+-- ('mkInitialReplayRootRegistry').
+--
+-- There is deliberately NO one-root-per-consumer enforcement: maintaining a
+-- single trie is the CONSUMER'S OWN responsibility (its disclosure service
+-- defines which trie its consumes resolve into). The controller is what keeps
+-- that sound against everyone else — a third party cannot fork someone else's
+-- replay scope, because claiming a root for @consumer@ requires @consumer@'s
+-- authority. Parallel roots can only be minted by the consumer itself (or its
+-- stolen key), which is self-harm of the same class as the signatory
+-- remainder above. Spam claims cost the spammer synchronizer traffic per
+-- transaction and the operator ~300 B of storage per worthless root; no
+-- shared contract grows. If consumer-key-compromise resilience is ever
+-- wanted, the hardening is trie-identity pinning: thread the original root's
+-- cid through successors (via @self@ in 'ConsumeDigest') and pin it in the
+-- app contract — documented, not built.
 template ReplayRootRegistry
   with
     operator : Party
-    granted  : Set Party
   where
     signatory operator
 
-    choice GrantReplayRoot : ContractId ReplayRootRegistry
+    nonconsuming choice ClaimReplayRoot : ContractId ReplayNode
       with
-        consumer : Party
-      controller operator
+        consumer       : Party
+        splitThreshold : Int  -- normally 'defaultSplitThreshold'; tiny in tests
+      controller consumer
       do
-        assertMsg "consumer already has a replay root" (not (Set.member consumer granted))
-        create this with granted = Set.insert consumer granted
-
--- | The consumer's half of the root-creation ceremony: a one-time
--- propose-accept per app. The consumer's signature on this request is what
--- authorizes its co-signature on the root; the operator accepts against its
--- registry, which enforces one-root-per-consumer.
-template ReplayRootRequest
-  with
-    consumer       : Party
-    operator       : Party
-    splitThreshold : Int  -- normally 'defaultSplitThreshold'; tiny in tests
-  where
-    signatory consumer
-    observer operator
-
-    choice ApproveReplayRoot : (ContractId ReplayRootRegistry, ContractId ReplayNode)
-      with
-        registryCid : ContractId ReplayRootRegistry  -- passed by cid: no keys
-      controller operator
-      do
-        reg <- fetch registryCid
-        assertMsg "registry belongs to a different operator" (reg.operator == operator)
-        regCid' <- exercise registryCid GrantReplayRoot with consumer
-        rootCid <- create ReplayNode with
+        create ReplayNode with
           consumer
           operator
           prefix = ""
           splitThreshold
           consumed = Set.empty
-        pure (regCid', rootCid)

--- a/canton/core/daml/Wormhole/Core/Replay.daml
+++ b/canton/core/daml/Wormhole/Core/Replay.daml
@@ -164,10 +164,9 @@ template ReplayRootRegistry
         create this with granted = Set.insert consumer granted
 
 -- | The consumer's half of the root-creation ceremony: a one-time
--- propose-accept per app (mirroring 'EmitterRequest'). The consumer's
--- signature on this request is what authorizes its co-signature on the root;
--- the operator accepts against its registry, which enforces
--- one-root-per-consumer.
+-- propose-accept per app. The consumer's signature on this request is what
+-- authorizes its co-signature on the root; the operator accepts against its
+-- registry, which enforces one-root-per-consumer.
 template ReplayRootRequest
   with
     consumer       : Party

--- a/canton/core/daml/Wormhole/Core/Setup.daml
+++ b/canton/core/daml/Wormhole/Core/Setup.daml
@@ -50,7 +50,7 @@ mkInitialCoreState operator guardianGovernance govChain govContract initialGuard
 
 -- | The emitter-id registry the operator creates alongside the 'CoreState' at
 -- setup. Emitter ids are allocated sequentially; it also carries
--- @guardianObserver@ for 'ApproveEmitter' to thread into each 'Emitter'.
+-- @guardianObserver@ for 'RegisterEmitter' to thread into each 'Emitter'.
 mkInitialEmitterRegistry : Party -> Party -> EmitterRegistry
 mkInitialEmitterRegistry operator guardianObserver =
   EmitterRegistry with operator, guardianObserver, nextId = 0

--- a/canton/core/daml/Wormhole/Core/Setup.daml
+++ b/canton/core/daml/Wormhole/Core/Setup.daml
@@ -55,9 +55,9 @@ mkInitialEmitterRegistry : Party -> Party -> EmitterRegistry
 mkInitialEmitterRegistry operator guardianObserver =
   EmitterRegistry with operator, guardianObserver, nextId = 0
 
--- | The replay-root registry the operator creates alongside the 'CoreState' at
--- setup. Grants each integrator consumer at most one 'ReplayNode' trie root
--- (see 'Wormhole.Core.Replay').
+-- | The replay-root registry (the stateless claim anchor) the operator
+-- creates alongside the 'CoreState' at setup. Hands a 'ReplayNode' trie root
+-- to any consumer that claims one (see 'Wormhole.Core.Replay').
 mkInitialReplayRootRegistry : Party -> ReplayRootRegistry
 mkInitialReplayRootRegistry operator =
-  ReplayRootRegistry with operator, granted = Set.empty
+  ReplayRootRegistry with operator

--- a/canton/core/daml/Wormhole/Core/State.daml
+++ b/canton/core/daml/Wormhole/Core/State.daml
@@ -6,25 +6,29 @@
 -- a single long-lived 'CoreState' that is archived and recreated on every
 -- governance transition.
 --
--- CONTRACT KEYS / UNIQUENESS: on Daml-LF 2.3 (Canton 3.5 / Protocol Version 35)
--- contract keys exist but are NOT unique — multiple active contracts may share a
--- key. So keys give ergonomics (look up / exercise by a stable key rather than a
--- churning contract-id), not a uniqueness guarantee. Two invariants are enforced
--- differently:
+-- CONTRACT ADDRESSING / UNIQUENESS: this package uses NO contract keys. On
+-- Daml-LF 2.3 keys are non-unique and resolve against the submission's readers
+-- (negative lookups fail open — see 'Wormhole.Core.Replay'), so they can carry
+-- neither uniqueness nor authenticity; even as a pure index they are a
+-- convenience the ledger does not underwrite. Contracts are addressed by
+-- CONTRACT-ID: stakeholders resolve current cids from their own ACS (the
+-- successor's cid arrives as a CreatedEvent of the consuming exercise), and
+-- non-stakeholders receive cids WITH explicit disclosures from the off-ledger
+-- disclosure service (README §4.7). Authenticity is checked on the PAYLOAD,
+-- never on how the cid was resolved: signatories cannot be forged, so a
+-- fetched or disclosed 'CoreState' whose @guardianGovernance@ field is the
+-- known governance party is authentic by construction — a compromised
+-- @operator@ cannot fabricate one (it lacks that signature). Two invariants:
 --   * 'CoreState' singleton: co-signed by the @operator@ and a @guardianGovernance@
---     party, and keyed by @guardianGovernance@. The @guardianGovernance@ party is
---     the guardians' governance anchor — in production a decentralized-namespace
---     external party controlled by a k-of-n threshold of guardian keys (the same
---     pattern as the Canton Network DSO party), rotated at the topology layer
---     without touching this template. Because it is a signatory AND the key
---     maintainer, a compromised @operator@ CANNOT fabricate a 'CoreState' bearing
---     the real governance party (that needs its signature) — so a lookup by the
---     known @guardianGovernance@ party can only ever resolve an authentic
---     'CoreState', and the operator cannot forge the guardian set. It signs only
---     at genesis; governance transitions ('SubmitGovernanceVAA') inherit its
---     authority from the archived contract, so the operator submits them alone.
---     "Exactly one" remains behavioral (operator + governance create one at
---     setup), but the guardian-set contents are now cryptographically anchored.
+--     party. The @guardianGovernance@ party is the guardians' governance anchor —
+--     in production a decentralized-namespace external party controlled by a
+--     k-of-n threshold of guardian keys (the same pattern as the Canton Network
+--     DSO party), rotated at the topology layer without touching this template.
+--     It signs only at genesis; governance transitions ('SubmitGovernanceVAA')
+--     inherit its authority from the archived contract, so the operator submits
+--     them alone. "Exactly one" remains behavioral (operator + governance create
+--     one at setup), but the guardian-set contents are cryptographically
+--     anchored by the co-signature.
 --   * Emitter identity: cryptographic. The 32-byte Wormhole address is
 --     @keccak256(tag ‖ registrar ‖ owner ‖ id)@ (see 'emitterAddressFor'), and
 --     the emitting @owner@ is a co-signatory. A compromised operator therefore
@@ -58,7 +62,7 @@ import Wormhole.Core.VAA
 -- @ExercisedEvent.exercise_result@ on the Ledger-API stream. Equivalent to the
 -- EVM @LogMessagePublished@ event.
 --
--- Instead of a 32-byte @sender@, the record carries the emitter's contract-key
+-- Instead of a 32-byte @sender@, the record carries the emitter's identity
 -- components: @registrar@, @owner@, and @emitterId@. The 32-byte Wormhole emitter
 -- address is @keccak256(tag ‖ registrar ‖ owner ‖ emitterId)@ ('emitterAddressFor'),
 -- derived by the watcher — the guardian is the sole source of truth for the
@@ -70,9 +74,9 @@ import Wormhole.Core.VAA
 -- watcher from the transaction's ledger effective time, NOT from this record, so
 -- it is intentionally absent here.
 data WormholeMessage = WormholeMessage with
-    registrar        : Party     -- Emitter key._1 (the operator); address input
-    owner            : Party     -- Emitter key._2 (the emitting party); address input
-    emitterId        : Int       -- Emitter key._3 (registry-allocated); address input
+    registrar        : Party     -- the operator; address input
+    owner            : Party     -- the emitting party; address input
+    emitterId        : Int       -- registry-allocated; address input
     sequence         : Int       -- uint64
     nonce            : Int       -- uint32
     consistencyLevel : Int       -- uint8
@@ -120,16 +124,13 @@ template CoreState
   where
     -- Co-signed: the operator advances the singleton, but the guardianGovernance
     -- party co-signs so the operator cannot forge the guardian set (see module
-    -- header). Keyed by guardianGovernance (its maintainer) so a lookup by the
-    -- known governance party resolves ONLY authentic CoreStates — the operator
-    -- cannot create one under that key. Governance transitions inherit
+    -- header) — a contract bearing the known governance party's signature is
+    -- authentic by construction. Governance transitions inherit
     -- guardianGovernance's authority from the archived contract, so it signs only
     -- at genesis.
     signatory operator, guardianGovernance
     -- Lets guardians watch guardian-set / governance transitions.
     observer guardianObserver
-    key guardianGovernance : Party
-    maintainer key
 
     -- | Read-only VAA verification, for the token bridge / external verifiers.
     -- Verifies against the CURRENT guardian set. @pubKeys@ are untrusted hints
@@ -159,6 +160,21 @@ template CoreState
       do
         now <- getTime
         either assertFail pure (verifyEncoded this encodedVAA pubKeys now)
+
+    -- | Read the operator off an authentic 'CoreState' — the caller-side
+    -- authenticity pin for anyone addressing this contract by cid. Templates
+    -- must opt in to third-party reads via a choice: a plain @fetch@ requires
+    -- a stakeholder of the fetched contract among the authorizers, and
+    -- explicit disclosure grants visibility, not fetch authority. This is
+    -- that opt-in — nonconsuming, flexible controller, touches nothing. The
+    -- result is bound by validation to the exercised contract, so a
+    -- fabricated "CoreState" returns its forged operator and fails the
+    -- caller's pin (see Test.ExampleIntegrator.Redeem).
+    nonconsuming choice GetOperator : Party
+      with
+        reader : Party
+      controller reader
+      do pure operator
 
     -- | Verify a VAA and record its consumption in @consumer@'s replay trie,
     -- atomically. Integrators (token bridge / NTT) call this in the same
@@ -276,17 +292,17 @@ currentSetForUpgrade st =
 emitterAddressTag : Text
 emitterAddressTag = "wormhole:emitter:v1"
 
--- | The 32-byte Wormhole emitter address of the 'Emitter' with key
+-- | The 32-byte Wormhole emitter address of the 'Emitter' identified by
 -- @(registrar, owner, emitterId)@.
 emitterAddressFor : Party -> Party -> Int -> Bytes32
 emitterAddressFor registrar owner emitterId =
   derivedAddress (DomainTag emitterAddressTag) registrar owner (RegistryId emitterId)
 
--- | Allocates monotonically increasing emitter ids, one registry per operator
--- (keyed by the operator party). Sequential-id discipline is operator-behavioral
--- (a non-unique key does not enforce it); what a rogue operator can NOT do is
--- reuse an id to impersonate an existing emitter — that address includes the
--- owner, whose signature it lacks (see 'Emitter').
+-- | Allocates monotonically increasing emitter ids, one registry per operator.
+-- Sequential-id discipline is operator-behavioral (nothing on-ledger enforces a
+-- single registry); what a rogue operator can NOT do is reuse an id to
+-- impersonate an existing emitter — that address includes the owner, whose
+-- signature it lacks (see 'Emitter').
 template EmitterRegistry
   with
     operator         : Party
@@ -294,8 +310,6 @@ template EmitterRegistry
     nextId           : Int
   where
     signatory operator
-    key operator : Party
-    maintainer key
 
     -- Returns guardianObserver for ApproveEmitter to stamp onto the new Emitter.
     choice AllocateEmitterId : (ContractId EmitterRegistry, Int, Party)
@@ -305,10 +319,10 @@ template EmitterRegistry
         pure (reg', nextId, guardianObserver)
 
 -- | A request by @requester@ to be granted an emitter. The operator approves it,
--- allocating a stable @emitterId@ from the 'EmitterRegistry' and creating the
--- 'Emitter' (keyed @(operator, requester, emitterId)@) in a single transaction.
--- The @requester@'s signature on this request is what authorizes the owner
--- co-signatory on the created 'Emitter'.
+-- allocating a stable @emitterId@ from its 'EmitterRegistry' (passed by cid —
+-- the operator resolves it from its own ACS) and creating the 'Emitter' in a
+-- single transaction. The @requester@'s signature on this request is what
+-- authorizes the owner co-signatory on the created 'Emitter'.
 template EmitterRequest
   with
     requester : Party
@@ -318,9 +332,13 @@ template EmitterRequest
     observer operator
 
     choice ApproveEmitter : ContractId Emitter
+      with
+        registryCid : ContractId EmitterRegistry
       controller operator
       do
-        (_, emitterId, guardianObserver) <- exerciseByKey @EmitterRegistry operator AllocateEmitterId
+        reg <- fetch registryCid
+        assertMsg "registry belongs to a different operator" (reg.operator == operator)
+        (_, emitterId, guardianObserver) <- exercise registryCid AllocateEmitterId
         create Emitter with
           operator
           owner = requester
@@ -329,16 +347,16 @@ template EmitterRequest
           emitterAddress = emitterAddressFor operator requester emitterId
           sequence = 0
 
--- | A registered emitter: the per-emitter sequence counter, identified by a
--- stable contract key @(operator, owner, emitterId)@. The sequence lives here
--- (not in 'CoreState') so the owner can publish permissionlessly (without
--- operator authority). Mirrors a Sui @EmitterCap@.
+-- | A registered emitter: the per-emitter sequence counter, identified by
+-- @(operator, owner, emitterId)@ in its payload. The sequence lives here (not
+-- in 'CoreState') so the owner can publish permissionlessly (without operator
+-- authority). Mirrors a Sui @EmitterCap@.
 template Emitter
   with
     operator         : Party
     owner            : Party
     guardianObserver : Party  -- read-only guardian observer
-    emitterId        : Int      -- registry-allocated; key._3
+    emitterId        : Int      -- registry-allocated
     emitterAddress   : Bytes32  -- emitterAddressFor operator owner emitterId, set at creation
     sequence         : Int      -- next sequence to assign
   where
@@ -350,16 +368,14 @@ template Emitter
     signatory operator, owner
     -- Lets guardians watch PublishMessage exercises and their results.
     observer guardianObserver
-    -- Non-unique key: stable across the sequence-bump churn so the owner can
-    -- publish again by key (ExerciseByKeyCommand) without tracking contract-ids.
-    key (operator, owner, emitterId) : (Party, Party, Int)
-    maintainer key._1
 
     -- | Publish a Wormhole message. The choice result is the 'WormholeMessage'
-    -- the watcher observes (decoded directly from @exercise_result@). The
-    -- sequence-bumped 'Emitter' is recreated with the SAME key (both signatures
-    -- inherited from the consumed contract), so the owner publishes again via
-    -- @exerciseByKey@ / @ExerciseByKeyCommand@ — no contract-id tracking. Mirrors
+    -- the watcher observes (decoded directly from @exercise_result@ — the
+    -- result type is a wire contract with the Go watcher; do not change it).
+    -- The sequence-bumped 'Emitter' is recreated with both signatures inherited
+    -- from the consumed contract; the owner is a signatory, so the successor's
+    -- cid arrives on its own ACS as the transaction's CreatedEvent and the next
+    -- publish addresses that cid directly. Mirrors
     -- @Implementation.publishMessage@.
     choice PublishMessage : WormholeMessage
       with

--- a/canton/core/daml/Wormhole/Core/State.daml
+++ b/canton/core/daml/Wormhole/Core/State.daml
@@ -306,46 +306,33 @@ emitterAddressFor registrar owner emitterId =
 template EmitterRegistry
   with
     operator         : Party
-    guardianObserver : Party  -- threaded into each new Emitter by ApproveEmitter
+    guardianObserver : Party  -- threaded into each new Emitter by RegisterEmitter
     nextId           : Int
   where
     signatory operator
 
-    -- Returns guardianObserver for ApproveEmitter to stamp onto the new Emitter.
-    choice AllocateEmitterId : (ContractId EmitterRegistry, Int, Party)
-      controller operator
+    -- | Direct, requester-submitted registration: allocates the next id and
+    -- creates the co-signed 'Emitter', one transaction, no operator crank. The
+    -- flexible controller brings the @requester@'s signature; the operator's
+    -- is INHERITED from this contract's signatory. Permissionless by design
+    -- (EVM/Sui parity: anyone may emit) — the requester only needs this
+    -- registry disclosed (README §4.7). Consuming, so racing registrations
+    -- contend here and exactly one commits; the loser re-resolves the fresh
+    -- registry cid and retries.
+    choice RegisterEmitter : (ContractId EmitterRegistry, ContractId Emitter)
+      with
+        requester : Party
+      controller requester
       do
         reg' <- create this with nextId = nextId + 1
-        pure (reg', nextId, guardianObserver)
-
--- | A request by @requester@ to be granted an emitter. The operator approves it,
--- allocating a stable @emitterId@ from its 'EmitterRegistry' (passed by cid —
--- the operator resolves it from its own ACS) and creating the 'Emitter' in a
--- single transaction. The @requester@'s signature on this request is what
--- authorizes the owner co-signatory on the created 'Emitter'.
-template EmitterRequest
-  with
-    requester : Party
-    operator  : Party
-  where
-    signatory requester
-    observer operator
-
-    choice ApproveEmitter : ContractId Emitter
-      with
-        registryCid : ContractId EmitterRegistry
-      controller operator
-      do
-        reg <- fetch registryCid
-        assertMsg "registry belongs to a different operator" (reg.operator == operator)
-        (_, emitterId, guardianObserver) <- exercise registryCid AllocateEmitterId
-        create Emitter with
+        emitter <- create Emitter with
           operator
           owner = requester
           guardianObserver
-          emitterId
-          emitterAddress = emitterAddressFor operator requester emitterId
+          emitterId = nextId
+          emitterAddress = emitterAddressFor operator requester nextId
           sequence = 0
+        pure (reg', emitter)
 
 -- | A registered emitter: the per-emitter sequence counter, identified by
 -- @(operator, owner, emitterId)@ in its payload. The sequence lives here (not

--- a/canton/test/daml/Test/ExampleIntegrator.daml
+++ b/canton/test/daml/Test/ExampleIntegrator.daml
@@ -29,7 +29,7 @@ import Wormhole.Core.Replay
 import Wormhole.Core.Setup
 import Wormhole.Core.State
 import Wormhole.Core.VAA (parseVAA)
-import Test.TestCore (setup, govSetFeeVAA, devnetGuardianPubKey)
+import Test.TestCore (setup, govSetFeeVAA, devnetGuardian, devnetGuardianPubKey)
 import Test.TestReplay (registerReplayRoot, coveringDisclosure)
 
 -- | Stand-in for the integrator's real effect (a mint / unlock). Co-signed:
@@ -47,6 +47,7 @@ template RedeemReceipt
 template ExampleIntegrator
   with
     manager     : Party    -- app party: signatory, and the replay scope
+    operator    : Party    -- the wormhole core operator this app trusts
     users       : [Party]  -- redeemers; observers so they can exercise Redeem
     peerChain   : Int      -- registered source-chain peer of this app
     peerAddress : Bytes32
@@ -70,6 +71,14 @@ template ExampleIntegrator
         pubKeys       : [(Int, Bytes)]
       controller redeemer
       do
+        -- Cids arrive from an untrusted submitter, so authenticate PAYLOADS:
+        -- a redeemer must not be able to point at a fabricated CoreState with
+        -- an attacker guardian set. A direct fetch is not authorized here (no
+        -- CoreState stakeholder among the authorizers — disclosure grants
+        -- visibility, not fetch authority), so the pin goes through the
+        -- 'GetOperator' read choice, which needs only its controller.
+        csOperator <- exercise coreStateCid GetOperator with reader = redeemer
+        assertMsg "unexpected core operator" (csOperator == operator)
         (vaa, _node) <- exercise coreStateCid VerifyAndConsumeVAA with
           encodedVAA
           pubKeys
@@ -100,6 +109,7 @@ setupIntegrator = do
   intCid <- submit manager do
     createCmd ExampleIntegrator with
       manager
+      operator
       users = [alice, bob]
       -- govSetFeeVAA is emitted by (chain 1, 0x..04); register that as the peer.
       peerChain = solanaGovernanceChainId
@@ -166,6 +176,7 @@ testIntegratorRedeem = do
   intCid2 <- submit manager2 do
     createCmd ExampleIntegrator with
       manager = manager2
+      operator
       users = [alice]
       peerChain = solanaGovernanceChainId
       peerAddress = defaultGovernanceContract
@@ -180,3 +191,21 @@ testIntegratorRedeem = do
       pubKeys = devnetPubKeys
   Some receipt2 <- queryContractId alice receipt2Cid
   receipt2.manager === manager2
+
+  -- A fabricated CoreState — attacker-signed, so its operator field cannot
+  -- name the real one — dies on the GetOperator pin before verification or
+  -- consumption run.
+  fakeOperator <- allocateParty "FakeOperator"
+  fakeGovernance <- allocateParty "FakeGovernance"
+  fakeObserver <- allocateParty "FakeObserver"
+  fakeCsId <- submit (actAs fakeOperator <> actAs fakeGovernance) do
+    createCmd (mkInitialCoreState fakeOperator fakeGovernance solanaGovernanceChainId
+                 defaultGovernanceContract [devnetGuardian] fakeObserver)
+  fakeDisc <- fromSome <$> queryDisclosure fakeOperator fakeCsId
+  submitMustFail (actAs alice <> disclose fakeDisc <> disclose freshDisc) do
+    exerciseCmd intCid Redeem with
+      redeemer = alice
+      coreStateCid = fakeCsId
+      replayNodeCid = freshCid
+      encodedVAA = govSetFeeVAA
+      pubKeys = devnetPubKeys

--- a/canton/test/daml/Test/TestCore.daml
+++ b/canton/test/daml/Test/TestCore.daml
@@ -33,7 +33,7 @@ govSetFeeVAA = "01000000000100710ab5dcf6885f62016990540e090400f26f41286382dab479
 -- co-signed by the @operator@ and a @guardianGovernance@ party (a single party
 -- here; in production a k-of-n threshold party), so genesis needs both. It also
 -- allocates the read-only @guardianObserver@ party and threads it into the
--- 'CoreState' and 'EmitterRegistry' (from which 'ApproveEmitter' carries it into
+-- 'CoreState' and 'EmitterRegistry' (from which 'RegisterEmitter' carries it into
 -- each 'Emitter'). Also creates the 'ReplayRootRegistry' (replay-trie root
 -- grants, see Test.TestReplay). The result keeps @operator@ FIRST so
 -- bootstrap.sh's first-party extraction still yields the operator;
@@ -49,14 +49,17 @@ setup = do
   _ <- submit operator do createCmd (mkInitialReplayRootRegistry operator)
   pure (operator, guardianObserver, csId)
 
--- | Register an emitter for @owner@: allocates a stable @emitterId@ from the
--- 'EmitterRegistry' (resolved from the operator's own ACS, passed by cid) and
--- creates the 'Emitter', returning its cid.
+-- | Register an emitter for @owner@, the production way: the requester submits
+-- alone against the disclosed 'EmitterRegistry' (served off-ledger by the
+-- disclosure service — simulated here by querying as the operator); the
+-- operator's co-signature on the 'Emitter' is inherited from the registry.
 registerEmitter : Party -> Party -> Script (ContractId Emitter)
 registerEmitter operator owner = do
-  reqId <- submit owner do createCmd EmitterRequest with requester = owner, operator
   [(regCid, _)] <- query @EmitterRegistry operator
-  submit operator do exerciseCmd reqId ApproveEmitter with registryCid = regCid
+  regDisc <- fromSome <$> queryDisclosure operator regCid
+  (_, emCid) <- submit (actAs owner <> disclose regDisc) do
+    exerciseCmd regCid RegisterEmitter with requester = owner
+  pure emCid
 
 -- | Publishing increments the per-emitter sequence and yields the expected
 -- 'WormholeMessage'. The message carries the emitter's identity components
@@ -291,9 +294,6 @@ testArchives = do
   Some cs <- queryContractId operator csId
   -- CoreState is co-signed, so archiving needs operator + guardianGovernance.
   submit (actAs operator <> actAs cs.guardianGovernance) do archiveCmd csId
-  alice <- allocateParty "ArchAlice"
-  reqId <- submit alice do createCmd EmitterRequest with requester = alice, operator
-  submit alice do archiveCmd reqId              -- Archive EmitterRequest
   bob <- allocateParty "ArchBob"
   emId <- registerEmitter operator bob
   -- Emitter now has two signatories (operator + owner), so both must authorize.

--- a/canton/test/daml/Test/TestCore.daml
+++ b/canton/test/daml/Test/TestCore.daml
@@ -50,16 +50,19 @@ setup = do
   pure (operator, guardianObserver, csId)
 
 -- | Register an emitter for @owner@: allocates a stable @emitterId@ from the
--- 'EmitterRegistry' and creates the keyed 'Emitter', returning its cid.
+-- 'EmitterRegistry' (resolved from the operator's own ACS, passed by cid) and
+-- creates the 'Emitter', returning its cid.
 registerEmitter : Party -> Party -> Script (ContractId Emitter)
 registerEmitter operator owner = do
   reqId <- submit owner do createCmd EmitterRequest with requester = owner, operator
-  submit operator do exerciseCmd reqId ApproveEmitter
+  [(regCid, _)] <- query @EmitterRegistry operator
+  submit operator do exerciseCmd reqId ApproveEmitter with registryCid = regCid
 
 -- | Publishing increments the per-emitter sequence and yields the expected
--- 'WormholeMessage'. The message carries the emitter's key components (the
--- watcher derives the 32-byte address as keccak256 of the canonicalised key);
--- the second publish exercises the stable key directly, with no cid tracking.
+-- 'WormholeMessage'. The message carries the emitter's identity components
+-- (the watcher derives the 32-byte address as keccak256 over them); the second
+-- publish resolves the sequence-bumped successor from the owner's own ACS —
+-- the direct-cid model needs no off-ledger service for stakeholders.
 testPublishMessage : Script ()
 testPublishMessage = do
   (operator, _, _) <- setup
@@ -78,10 +81,11 @@ testPublishMessage = do
   msg0.nonce === 7
   msg0.payload === "deadbeef"
 
-  -- The sequence-bumped Emitter is recreated under the SAME key, so the next
-  -- publish exercises it by key — no active-contract-set query, no cid tracking.
+  -- The sequence-bumped successor's cid arrives on the owner's ACS (the owner
+  -- is a signatory), so the next publish addresses it directly.
+  [(emitterId', _)] <- query @Emitter alice
   msg1 <- submit alice do
-    exerciseByKeyCmd @Emitter (operator, alice, 0) PublishMessage with
+    exerciseCmd emitterId' PublishMessage with
       nonce = 8, payload = "cafe", consistencyLevel = 0
   msg1.sequence === 1
   msg1.registrar === operator
@@ -103,7 +107,7 @@ testRegistryAllocation = do
   a.emitterId === 0
   b.emitterId === 1
   assert (a.emitterAddress /= b.emitterAddress)
-  Some (_, reg) <- queryByKey @EmitterRegistry operator operator
+  [(_, reg)] <- query @EmitterRegistry operator
   reg.nextId === 2
 
 -- | Pins the canonical emitter-address encoding against the cross-language test
@@ -125,8 +129,8 @@ testAddressVector =
 --       (missing the owner's signature); and
 --   (b) even colluding with another party, the best it can do is a contract with
 --       a DIFFERENT owner, which derives a different (untrusted) address.
--- This is the invariant guardians verify by replay. Canton keys are non-unique,
--- so registry-id discipline is behavioral — but address integrity is not.
+-- This is the invariant guardians verify by replay. Registry-id discipline is
+-- behavioral — but address integrity is not.
 testImpersonationBlocked : Script ()
 testImpersonationBlocked = do
   (operator, guardianObserver, _) <- setup
@@ -237,16 +241,14 @@ integrationParseAndVerifyVAAByExternalVerifier = do
   vaa.sequence === 1
   pure tokenBridge
 
--- | A SetMessageFee governance VAA verifies and updates the message fee. Looks up
--- the stable governance anchor once, then exercises by the 'CoreState' key
--- (ExerciseByKeyCommand) — so governance needs no contract-id tracking, and the
--- operator submits alone (guardianGovernance's authority is inherited).
+-- | A SetMessageFee governance VAA verifies and updates the message fee. The
+-- operator addresses the 'CoreState' by cid from its own ACS and submits alone
+-- (guardianGovernance's authority is inherited from the archived contract).
 testGovernanceSetMessageFee : Script ()
 testGovernanceSetMessageFee = do
   (operator, _, csId) <- setup
-  Some cs0 <- queryContractId operator csId
   newCsId <- submit operator do
-    exerciseByKeyCmd @CoreState cs0.guardianGovernance SubmitGovernanceVAA with
+    exerciseCmd csId SubmitGovernanceVAA with
       encodedVAA = govSetFeeVAA
       pubKeys = [(0, devnetGuardianPubKey)]
   Some cs <- queryContractId operator newCsId
@@ -257,30 +259,28 @@ testGovernanceSetMessageFee = do
 testGovernanceReplayRejected : Script ()
 testGovernanceReplayRejected = do
   (operator, _, csId) <- setup
-  Some cs0 <- queryContractId operator csId
-  _ <- submit operator do
-    exerciseByKeyCmd @CoreState cs0.guardianGovernance SubmitGovernanceVAA with
+  newCsId <- submit operator do
+    exerciseCmd csId SubmitGovernanceVAA with
       encodedVAA = govSetFeeVAA
       pubKeys = [(0, devnetGuardianPubKey)]
   submitMustFail operator do
-    exerciseByKeyCmd @CoreState cs0.guardianGovernance SubmitGovernanceVAA with
+    exerciseCmd newCsId SubmitGovernanceVAA with
       encodedVAA = govSetFeeVAA
       pubKeys = [(0, devnetGuardianPubKey)]
 
 -- | Integration entrypoint, invoked by the Go integration test via
 -- `dpm script` (NOT by `dpm test`): set up the bridge, register an emitter,
--- publish one message (nonce 42, payload 0x11223344) by key, and return the
--- Operator party so the watcher can read the ledger as it. The publish uses
--- ExerciseByKeyCommand, so this also exercises the key path against a live
--- Canton ledger. The emitter address is not chosen here: the watcher derives it
--- from the message's key components, which the Go test recomputes.
+-- publish one message (nonce 42, payload 0x11223344) by cid, and return the
+-- Operator party so the watcher can read the ledger as it. The emitter address
+-- is not chosen here: the watcher derives it from the message's identity
+-- components, which the Go test recomputes.
 integrationPublish : Script Party
 integrationPublish = do
   (operator, _, _) <- setup
   owner <- allocateParty "IntegrationEmitter"
-  _ <- registerEmitter operator owner
+  emId <- registerEmitter operator owner
   _ <- submit owner do
-    exerciseByKeyCmd @Emitter (operator, owner, 0) PublishMessage with
+    exerciseCmd emId PublishMessage with
       nonce = 42, payload = "11223344", consistencyLevel = 0
   pure operator
 
@@ -298,6 +298,6 @@ testArchives = do
   emId <- registerEmitter operator bob
   -- Emitter now has two signatories (operator + owner), so both must authorize.
   submit (actAs operator <> actAs bob) do archiveCmd emId   -- Archive Emitter
-  Some (regId, _) <- queryByKey @EmitterRegistry operator operator
+  [(regId, _)] <- query @EmitterRegistry operator
   submit operator do archiveCmd regId           -- Archive EmitterRegistry
   pure ()

--- a/canton/test/daml/Test/TestGuardianObserver.daml
+++ b/canton/test/daml/Test/TestGuardianObserver.daml
@@ -24,9 +24,9 @@ import Wormhole.Core.Setup
 import Test.TestCore (setup, registerEmitter, devnetGuardian, govSetFeeVAA, devnetGuardianPubKey)
 
 -- | The observer is a stakeholder of the message surface, so after a publish it
--- can query the sequence-bumped 'Emitter' by key and via 'query @Emitter'. This
--- is the Script-level proxy for "informee of the consuming 'PublishMessage'
--- exercise" — i.e. it observes the message on the update stream.
+-- sees the sequence-bumped 'Emitter' via 'query @Emitter'. This is the
+-- Script-level proxy for "informee of the consuming 'PublishMessage' exercise"
+-- — i.e. it observes the message on the update stream.
 testObserverSeesPublishedMessage : Script ()
 testObserverSeesPublishedMessage = do
   (operator, guardianObserver, _) <- setup
@@ -35,14 +35,12 @@ testObserverSeesPublishedMessage = do
   _ <- submit alice do
     exerciseCmd emitterId PublishMessage with nonce = 7, payload = "deadbeef", consistencyLevel = 0
 
-  -- The observer sees the post-publish Emitter (recreated under the same key
-  -- with the sequence bumped) both by key and via an ACS query.
-  Some (_, em) <- queryByKey @Emitter guardianObserver (operator, alice, 0)
+  -- The observer sees the post-publish Emitter (recreated with the sequence
+  -- bumped) on its ACS.
+  [(_, em)] <- query @Emitter guardianObserver
   em.sequence === 1
   em.owner === alice
   em.guardianObserver === guardianObserver
-  emitters <- query @Emitter guardianObserver
-  assertMsg "observer should see at least one Emitter" (not (null emitters))
 
 -- | The observer is a stakeholder of 'CoreState', so it reads the current
 -- guardian set and — because 'SubmitGovernanceVAA' is consuming — the successor
@@ -56,7 +54,7 @@ testObserverSeesCoreState = do
   gs.keys === [devnetGuardian]
 
   newCsId <- submit operator do
-    exerciseByKeyCmd @CoreState cs.guardianGovernance SubmitGovernanceVAA with
+    exerciseCmd csId SubmitGovernanceVAA with
       encodedVAA = govSetFeeVAA
       pubKeys = [(0, devnetGuardianPubKey)]
   Some cs' <- queryContractId guardianObserver newCsId
@@ -79,7 +77,7 @@ testObserverHasNoAuthority = do
 
   -- Cannot drive governance.
   submitMustFail guardianObserver do
-    exerciseByKeyCmd @CoreState cs.guardianGovernance SubmitGovernanceVAA with
+    exerciseCmd csId SubmitGovernanceVAA with
       encodedVAA = govSetFeeVAA
       pubKeys = [(0, devnetGuardianPubKey)]
 
@@ -140,7 +138,7 @@ testObserverDoesNotSeeOutOfScope = do
 
   -- EmitterRegistry is out of scope (it carries the observer as a field for
   -- threading, but does not name it as a template observer).
-  Some (regId, _) <- queryByKey @EmitterRegistry operator operator
+  [(regId, _)] <- query @EmitterRegistry operator
   regView <- queryContractId guardianObserver regId
   regView === None
   regs <- query @EmitterRegistry guardianObserver

--- a/canton/test/daml/Test/TestGuardianObserver.daml
+++ b/canton/test/daml/Test/TestGuardianObserver.daml
@@ -122,19 +122,11 @@ testPublishRequiresOnlyOwner = do
   pure ()
 
 -- | The observer is scoped to the attestation surface only. It is NOT a
--- stakeholder of pre-approval intent ('EmitterRequest') or id allocation
--- ('EmitterRegistry'), so neither is visible to it — least privilege.
+-- stakeholder of id allocation ('EmitterRegistry'), so that is not visible to
+-- it — least privilege.
 testObserverDoesNotSeeOutOfScope : Script ()
 testObserverDoesNotSeeOutOfScope = do
   (operator, guardianObserver, _) <- setup
-  requester <- allocateParty "Requester"
-  reqId <- submit requester do createCmd EmitterRequest with requester, operator
-
-  -- EmitterRequest is out of scope.
-  reqView <- queryContractId guardianObserver reqId
-  reqView === None
-  reqs <- query @EmitterRequest guardianObserver
-  assertMsg "observer must not see EmitterRequests" (null reqs)
 
   -- EmitterRegistry is out of scope (it carries the observer as a field for
   -- threading, but does not name it as a template observer).

--- a/canton/test/daml/Test/TestReplay.daml
+++ b/canton/test/daml/Test/TestReplay.daml
@@ -29,26 +29,31 @@ pad64 t = t <> mconcat (replicate (64 - T.length t) "0")
 nibbles : [Text]
 nibbles = T.explode "0123456789abcdef"
 
--- | Propose-accept ceremony granting @consumer@ its trie root: the consumer
--- requests, the operator approves against its (queried, cid-passed — no keys)
--- 'ReplayRootRegistry'.
+-- | Direct, consumer-submitted root claim: the consumer holds the one static
+-- disclosure of the 'ReplayRootRegistry' anchor (served off-ledger by the
+-- disclosure service — simulated here by reading as the operator, and
+-- cacheable forever since the anchor never churns) and submits alone. No
+-- operator crank.
 registerReplayRoot : Party -> Party -> Int -> Script (ContractId ReplayNode)
 registerReplayRoot operator consumer threshold = do
-  reqCid <- submit consumer do
-    createCmd ReplayRootRequest with consumer, operator, splitThreshold = threshold
   [(regCid, _)] <- query @ReplayRootRegistry operator
-  (_, rootCid) <- submit operator do
-    exerciseCmd reqCid ApproveReplayRoot with registryCid = regCid
-  pure rootCid
+  regDisc <- fromSome <$> queryDisclosure operator regCid
+  submit (actAs consumer <> disclose regDisc) do
+    exerciseCmd regCid ClaimReplayRoot with
+      consumer
+      splitThreshold = threshold
 
 -- | The disclosure-service lookup: the unique active node of @consumer@'s trie
--- covering @digest@. Aborts if coverage is not exactly one — every call doubles
--- as a check of the partition invariant.
+-- covering @digest@, queried as @consumer@. The filter matches the trie owner
+-- too, because a reader can see nodes of several tries (the operator co-signs
+-- all of them). Aborts if coverage is not exactly one — every call doubles as
+-- a check of the partition invariant, and this abort is also how the service
+-- detects a forked trie (a consumer that minted parallel roots).
 coveringNode : Party -> Text -> Script (ContractId ReplayNode, ReplayNode)
 coveringNode consumer digest = do
   nodes <- query @ReplayNode consumer
   let d = normalizeHex digest
-  case filter (\(_, n) -> n.prefix `T.isPrefixOf` d) nodes of
+  case filter (\(_, n) -> n.consumer == consumer && n.prefix `T.isPrefixOf` d) nodes of
     [one] -> pure one
     covering -> abort ("partition invariant violated: " <> show (length covering) <> " covering nodes")
 
@@ -254,30 +259,41 @@ testNodeArchiveNeedsBoth = do
   submitMustFail consumer do archiveCmd rootCid
   submitMustFail operator do archiveCmd rootCid
   -- Both together can (the irreducible signatory remainder) — coverage for the
-  -- auto-generated Archive choices, including request and registry.
+  -- auto-generated Archive choices, including the registry anchor.
   submit (actAs consumer <> actAs operator) do archiveCmd rootCid
-  reqCid <- submit consumer do
-    createCmd ReplayRootRequest with consumer, operator, splitThreshold = 4
-  submit consumer do archiveCmd reqCid
   [(regCid, _)] <- query @ReplayRootRegistry operator
   submit operator do archiveCmd regCid
 
--- | The root registry grants at most one root per consumer — the positive,
--- on-ledger check that replaces key uniqueness — and roots cannot be minted
--- outside it (the consumer alone lacks the operator's signature).
-testRootRegistry : Script ()
-testRootRegistry = do
+-- | Root claims are free and self-serve; what the registry pins down is WHOSE
+-- scope a claim can touch. Claiming a root for a consumer requires that
+-- consumer's authority — the load-bearing property: nobody can fork someone
+-- ELSE'S replay scope. A consumer duplicating its own root is deliberately
+-- possible (pinned below): parallel roots are self-harm, detected off-ledger
+-- by the disclosure service ('coveringNode' aborts on more than one covering
+-- node). Roots cannot be minted outside the registry — the consumer alone
+-- lacks the operator's signature.
+testRootClaims : Script ()
+testRootClaims = do
   (operator, consumer, rootCid) <- setupTrie 4
   Some root <- queryContractId consumer rootCid
   root.prefix === ""
   root.splitThreshold === 4
   Set.size root.consumed === 0
-  -- A second grant for the same consumer is rejected.
-  reqCid <- submit consumer do
-    createCmd ReplayRootRequest with consumer, operator, splitThreshold = 4
   [(regCid, _)] <- query @ReplayRootRegistry operator
-  submitMustFail operator do
-    exerciseCmd reqCid ApproveReplayRoot with registryCid = regCid
+  regDisc <- fromSome <$> queryDisclosure operator regCid
+  -- A third party cannot claim a root for someone else's scope.
+  mallory <- allocateParty "TrieMallory"
+  submitMustFail (actAs mallory <> disclose regDisc) do
+    exerciseCmd regCid ClaimReplayRoot with
+      consumer
+      splitThreshold = 4
+  -- The consumer CAN duplicate its own root — by design, self-harm only.
+  _ <- submit (actAs consumer <> disclose regDisc) do
+    exerciseCmd regCid ClaimReplayRoot with
+      consumer
+      splitThreshold = 4
+  roots <- query @ReplayNode consumer
+  length roots === 2
   -- The consumer cannot create a co-signed node alone.
   submitMustFail consumer do
     createCmd ReplayNode with

--- a/node/pkg/watchers/canton/watcher_integration_test.go
+++ b/node/pkg/watchers/canton/watcher_integration_test.go
@@ -145,9 +145,8 @@ func TestCantonWatcherIntegration(t *testing.T) {
 	select {
 	case ev := <-eventChan:
 		// The decoded event from the live ledger. The address is derived from the
-		// emitter's key components (registrar/owner/emitterId) assigned by the live
-		// ledger; publishing went via ExerciseByKeyCommand (integrationPublish), so
-		// this also exercises the key path end-to-end.
+		// emitter's identity components (registrar/owner/emitterId) assigned by
+		// the live ledger (integrationPublish exercises the Emitter by cid).
 		require.NotEmpty(t, ev.Message.Registrar)
 		require.NotEmpty(t, ev.Message.Owner)
 		require.Contains(t, ev.Message.Registrar, "::", "registrar should be a full party id")


### PR DESCRIPTION
## The problem

After the replay-protection redesign (#38), contract keys survived in the package only as indexes: `CoreState` keyed by the governance anchor, `EmitterRegistry` keyed by the operator, `Emitter` keyed by `(operator, owner, emitterId)`. None of them carried authority or uniqueness — those never came from keys — but even the indexing role is not something the ledger underwrites: LF 2.3 key resolution happens once, on the submitting participant, against the submission's readers, so a key is just a submitter-local convenience wearing the syntax of a guarantee. Worse, the key-based *authenticity* story ("a lookup by the known governance party resolves only authentic CoreStates") quietly depended on that resolution being trustworthy, which it is not for anyone but the maintainer itself.

The keys also propped up a pattern worth naming: our propose-accept flows used the accept side for the operator's *visibility* (resolving the registry by key from its own view), not for its authority — which is inheritable. Keeping keys meant keeping cranks.

## The solution

Contracts are addressed **by contract-id**, and authenticity moves to where it always actually lived: the **payload**. Signatories cannot be forged, so a fetched or disclosed `CoreState` naming the known governance anchor is authentic however its cid was found. Stakeholders resolve current cids from their own ACS (a consuming exercise delivers the successor's `CreatedEvent` to every stakeholder — publishers, the operator, and governance need no off-ledger help at all); non-stakeholders get cid + explicit disclosure from the **disclosure service** we already run for the replay trie. README §4.7 is the aggregation document: every resolution the service must serve, who needs an attachment, and churn rates — with the standing rule that the service is trusted for liveness only, since consumers authenticate payloads, never resolution paths.

With visibility outsourced and authority inherited, the cranks collapse into direct flows:

- **Emitter registration is permissionless and requester-submitted**: `RegisterEmitter` on the disclosed registry allocates the id and creates the co-signed `Emitter` in one transaction — the operator's signature is inherited from the registry, matching EVM/Sui where anyone may emit. The request/approve templates are gone. (The registry holds only `nextId : Int`, so permissionless writes cannot bloat it.)
- **Replay-trie roots are free and consumer-claimed**: `ReplayRootRegistry` shrinks to a stateless, never-churning anchor whose nonconsuming `ClaimReplayRoot` mints a co-signed root for whoever asks — for themselves. We deliberately dropped one-root-per-consumer enforcement after walking the alternatives (an on-ledger granted set is sybil-spammable past the request caps; gating disclosures promotes the service into a security control and leaks via witnessed successor blobs; operator-issued grants put a guardian-multisig signing ceremony on every onboarding). The load-bearing property is that claiming a root for a consumer requires *that consumer's* authority: nobody can fork someone else's replay scope. Parallel roots for your own scope are self-harm, detected off-ledger by the disclosure service (two covering nodes for one digest), and a stolen consumer key defeats an app more directly than replay anyway — with trie-identity pinning documented as the hardening if that trade ever changes. This is EVM parity: nobody grants replay storage there either.

One consequence worth calling out for integrators: a non-stakeholder cannot `fetch` a disclosed contract (fetch authorization requires a stakeholder among the authorizers — disclosure grants visibility, not fetch authority). Templates must opt in to third-party reads via a choice, so `CoreState` exposes a nonconsuming, flexible-controller `GetOperator` — its result is bound by validation to the exercised contract, making it the caller-side authenticity pin. The reference integrator asserts it against its configured operator before verifying anything, so a redeemer pointing at a fabricated `CoreState` (attacker guardian set) dies on the first line.

Operationally, the operator party's active signing surface after genesis is now **empty**: registration, root claims, splits, and governance transitions all reach its signature by inheritance. If the operator is stood up as a k-of-n guardian threshold party (the existing §9 external-party machinery), the interactive-submission ceremony is needed for genesis only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
